### PR TITLE
Solcast switch no history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,20 @@
 **[0.13.2] – 2024-XX-XX**
 
-Änderung auch in SymoGen24Controller2.py
+Änderung in SymoGen24Controller2.py
 - die Akkuschonung wird jetzt immer ausgeführt, wenn die Variable "Akkuschonung = 1" ist. 
+
+Änderung in Solcast_WeatherData.py
+- hier kann nun auch eine zweite Ausrichtung, die in solcast.com mir 1km Entfernung 
+  konfiguriert werden kann, abgerufen werden. 
+  [pv.strings] anzahl auf 2 setzen.
+
+- damit die freien 10 Abrufe nicht zu schnell verbraucht werden, 
+  kann auf das Abrufen der Historie durch no_history = 1 abgestellt werden.
+  Die Historie und die aktuelle Stunde werden dann aus der weatherData.json übernommen.
+
+#### ACHTUNG Änderung in der config.ini:
+- Im Block [solcast.com] wurde "no_history = 0" hinzugefügt
+- ein neuer Block [solcast.com2] wurde hizugefügt.
 
 **[0.13.1] – 2024-03-17**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   [pv.strings] anzahl auf 2 setzen.
 
 - damit die freien 10 Abrufe nicht zu schnell verbraucht werden, 
-  kann auf das Abrufen der Historie durch no_history = 1 abgestellt werden.
+  kann das Abrufen der Historie durch no_history = 1 abgestellt werden.
   Die Historie und die aktuelle Stunde werden dann aus der weatherData.json übernommen.
 
 #### ACHTUNG Änderung in der config.ini:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ SymoGen24Controller2.py durchgehend alle 5 Minuten starten wegen Logging.
 (Häufigerer Aufruf nicht sinnvoll, da der Gen24 die Zähler nur alle 5 Minuten aktualisiert!)  
 
 ```
-*/5 * * * * /DIR/start_PythonScript.sh SymoGen24Controller2.py schreiben
+1-56/5 * * * * /DIR/start_PythonScript.sh SymoGen24Controller2.py schreiben
 33 5,8,10,12,14,19 * * * /DIR/start_PythonScript.sh WeatherDataProvider2.py
 8 5,7,9,11,13,15,17 * * * /DIR/start_PythonScript.sh Solarprognose_WeatherData.py
 1 6,8,11,13,15 * * * /DIR/start_PythonScript.sh Solcast_WeatherData.py

--- a/config.ini
+++ b/config.ini
@@ -4,7 +4,7 @@
 filePathWeatherData = weatherData.json
 
 ; Wenn ein zweites Feld mit anderer Ausrichtung vorhanden ist, hier Anzahl=2 eintragen
-; und die Werte unter [forecast.solar2] eintragen
+; und die Werte unter [forecast.solar2] und/oder [solcast.com2] eintragen
 [pv.strings]
 anzahl = 1
 
@@ -46,6 +46,10 @@ resource_id = xxxx-xxxx-xxxx-xxxx
 dataAgeMaxInMinutes = 1000
 ; Zeitversatz zu UTC, hier für Zeitzone Europe/Berlin UTC +1, Sommerzeit = +1 erfolgt nun automatisch.
 Zeitzone = +1
+KW_Faktor = 1.00
+
+[solcast.com2]
+resource_id = xxxx-xxxx-xxxx-xxxx
 KW_Faktor = 1.00
 
 [gen24]

--- a/config.ini
+++ b/config.ini
@@ -49,7 +49,7 @@ Zeitzone = +1
 KW_Faktor = 1.00
 ; Wenn no_history = 1 dann werden von solcast.com keine historischen Daten geholt, sondern aus weatherData.json
 ; dadurch hat man bei einer Ausrichtung 10 und bei zwei Ausrichtungen 5 Abfragen
-no_history = 1
+no_history = 0
 
 [solcast.com2]
 resource_id = xxxx-xxxx-xxxx-xxxx

--- a/config.ini
+++ b/config.ini
@@ -47,6 +47,9 @@ dataAgeMaxInMinutes = 1000
 ; Zeitversatz zu UTC, hier für Zeitzone Europe/Berlin UTC +1, Sommerzeit = +1 erfolgt nun automatisch.
 Zeitzone = +1
 KW_Faktor = 1.00
+; Wenn no_history = 1 dann werden von solcast.com keine historischen Daten geholt, sondern aus weatherData.json
+; dadurch hat man bei einer Ausrichtung 10 und bei zwei Ausrichtungen 5 Abfragen
+no_history = 1
 
 [solcast.com2]
 resource_id = xxxx-xxxx-xxxx-xxxx

--- a/config.ini.info
+++ b/config.ini.info
@@ -74,6 +74,10 @@ dataAgeMaxInMinutes = 1000
 Zeitzone = +1
 ; falls die Anlagengröße in KWp nicht mit der Größe in solcast.com übereinstimmt (z.B. Erweiterung)
 KW_Faktor = 1.00
+; Wenn no_history = 1 dann werden von solcast.com keine historischen Daten geholt, sondern aus weatherData.json
+; dadurch hat man bei einer Ausrichtung 10 und bei zwei Ausrichtungen 5 Abfragen
+no_history = 1
+
 
 [solcast.com2]
 resource_id = xxxx-xxxx-xxxx-xxxx

--- a/config.ini.info
+++ b/config.ini.info
@@ -11,7 +11,7 @@
 filePathWeatherData=weatherData.json
 
 ; Wenn ein zweites Feld mit anderer Ausrichtung vorhanden ist, hier Anzahl=2 eintragen
-; und die Werte für das zweite PV-Feld unter [forecast.solar2] eintragen
+; und die Werte unter [forecast.solar2] und/oder [solcast.com2] eintragen
 [pv.strings]
 anzahl=1
 
@@ -75,6 +75,9 @@ Zeitzone = +1
 ; falls die Anlagengröße in KWp nicht mit der Größe in solcast.com übereinstimmt (z.B. Erweiterung)
 KW_Faktor = 1.00
 
+[solcast.com2]
+resource_id = xxxx-xxxx-xxxx-xxxx
+KW_Faktor = 1.00
 
 [gen24]
 ; IP des Wechselrichters


### PR DESCRIPTION
Schalter no_history in Solcast_WeatherData.py eingeführt,
um ohne zurückliegende Prognosen abzufragen, und dadurch weniger Anrufe
zu verbrauchen. Dann werden die zurückliegenden PrognoseDaten des Tages
aus der weatherData.json geholt.

