### PR TITLE
Vereinfachung des Programmcodes zur Ermittlung des Ladewertes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 **[0.24.3] – 2024-09-01**  
 
-Vereinfachung des Programmcodes zur Ermittlung des Ladewertes
-Akkuzustand in Prozent aus API ausgeben.
+Vereinfachung des Programmcodes zur Ermittlung des Ladewertes.  
+Akkuzustand in Prozent aus API ausgeben.  
 
 **Neuerungen bei Ladewertberechnung**  
-Bei BatSparFaktor < 1 wird morgens bei folgenden Bedingungen die Ladung auf 0 gestellt:  
+Bei BatSparFaktor < 1 wird morgens bei folgender Bedingung die Ladung auf 0 gestellt:  
 Prognoseladewert < Grenze_nachOben*0.7"  
 
-Wenn Ladewert ohne BatSparFaktor größer MaxLadung = MaxLadung, damit der Akku auch voll wird.  
+Wenn der Ladewert ohne BatSparFaktor größer MaxLadung, dann MaxLadung setzen, damit der Akku auch voll wird.  
 
 **Neuerungen bei Eigenverbrauchs-Optimierung**  
 Durch EigenverbOpt_steuern = 2, in der CONFIG/charge_priv.ini wird die Einspeisung am Tag auf Null gesetzt.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+**[0.24.3] – 2024-XX-XX**  
+
+Vereinfachung des Programmcodes zur Ermittlung des Ladewertes
+
+**Neuerungen bei Ladewertberechnung**  
+
+Bei BatSparFaktor < 1 wird morgens bei folgenden Bedingungen die Ladung auf 0 gestellt:  
+Prognose < WRSchreibGrenze_nachOben + Grundlast 
+Prognoseladewert < Grenze_nachOben/2"
+
+Wenn Ladewert ohne BatSparFaktor größer MaxLadung = MaxLadung, damit der Akku auch voll wird
+
 **[0.24.2] – 2024-08-25**  
 
 FIX: Symos sind nachts evtl. im Standby und liefern keine Daten.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 Vereinfachung des Programmcodes zur Ermittlung des Ladewertes
 
 **Neuerungen bei Ladewertberechnung**  
-
 Bei BatSparFaktor < 1 wird morgens bei folgenden Bedingungen die Ladung auf 0 gestellt:  
 Prognoseladewert < Grenze_nachOben*0.7"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-**[0.24.3] – 2024-XX-XX**  
+**[0.24.3] – 2024-09-01**  
 
 Vereinfachung des Programmcodes zur Ermittlung des Ladewertes
+Akkuzustand in Prozent aus API ausgeben.
 
 **Neuerungen bei Ladewertberechnung**  
 Bei BatSparFaktor < 1 wird morgens bei folgenden Bedingungen die Ladung auf 0 gestellt:  
@@ -9,11 +10,11 @@ Prognoseladewert < Grenze_nachOben*0.7"
 Wenn Ladewert ohne BatSparFaktor größer MaxLadung = MaxLadung, damit der Akku auch voll wird.  
 
 **Neuerungen bei Eigenverbrauchs-Optimierung**  
-Durch EigenverbOpt_steuern = 2, in der CONFIG/charge_priv.ini wird die Einspeisug am Tag auf Null gesetzt.  
+Durch EigenverbOpt_steuern = 2, in der CONFIG/charge_priv.ini wird die Einspeisung am Tag auf Null gesetzt.  
 
 #### ACHTUNG Änderung in der html/config.php:  
 Eine neu Variable $Diagrammgrenze = 25000; wurde eingefügt, bitte in html/config_priv.php einfügen.  
-Daurch wird die Y-Achse des Diagramms in der QZ-Bilanz auf diese Größe begrenzt, um große Ausreisser
+Dadurch wird die Y-Achse des Tagesdiagramms in der QZ-Bilanz auf diese Größe begrenzt, um große Ausreißer
 in dem Diagramm abzufangen, die durch längeren Loggingausfall entstehen können.
 
 **[0.24.2] – 2024-08-25**  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Vereinfachung des Programmcodes zur Ermittlung des Ladewertes
 **Neuerungen bei Ladewertberechnung**  
 
 Bei BatSparFaktor < 1 wird morgens bei folgenden Bedingungen die Ladung auf 0 gestellt:  
-Prognose < WRSchreibGrenze_nachOben + Grundlast 
+Prognose < Grundlast 
 Prognoseladewert < Grenze_nachOben/2"
 
 Wenn Ladewert ohne BatSparFaktor größer MaxLadung = MaxLadung, damit der Akku auch voll wird

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Prognoseladewert < Grenze_nachOben*0.7"
 
 Wenn Ladewert ohne BatSparFaktor größer MaxLadung = MaxLadung, damit der Akku auch voll wird
 
+**Neuerungen bei Eigenverbrauchs-Optimierung**
+Durch EigenverbOpt_steuern = 2, in der CONFIG/charge_priv.ini wird die Einspeisug am Tag auf Null gesetzt.
+
 **[0.24.2] – 2024-08-25**  
 
 FIX: Symos sind nachts evtl. im Standby und liefern keine Daten.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@ Vereinfachung des Programmcodes zur Ermittlung des Ladewertes
 **Neuerungen bei Ladewertberechnung**  
 
 Bei BatSparFaktor < 1 wird morgens bei folgenden Bedingungen die Ladung auf 0 gestellt:  
-Prognose < Grundlast 
-Prognoseladewert < Grenze_nachOben/2"
+Prognoseladewert < Grenze_nachOben*0.7"
 
 Wenn Ladewert ohne BatSparFaktor größer MaxLadung = MaxLadung, damit der Akku auch voll wird
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,17 @@ Vereinfachung des Programmcodes zur Ermittlung des Ladewertes
 
 **Neuerungen bei Ladewertberechnung**  
 Bei BatSparFaktor < 1 wird morgens bei folgenden Bedingungen die Ladung auf 0 gestellt:  
-Prognoseladewert < Grenze_nachOben*0.7"
+Prognoseladewert < Grenze_nachOben*0.7"  
 
-Wenn Ladewert ohne BatSparFaktor größer MaxLadung = MaxLadung, damit der Akku auch voll wird
+Wenn Ladewert ohne BatSparFaktor größer MaxLadung = MaxLadung, damit der Akku auch voll wird.  
 
-**Neuerungen bei Eigenverbrauchs-Optimierung**
-Durch EigenverbOpt_steuern = 2, in der CONFIG/charge_priv.ini wird die Einspeisug am Tag auf Null gesetzt.
+**Neuerungen bei Eigenverbrauchs-Optimierung**  
+Durch EigenverbOpt_steuern = 2, in der CONFIG/charge_priv.ini wird die Einspeisug am Tag auf Null gesetzt.  
+
+#### ACHTUNG Änderung in der html/config.php:  
+Eine neu Variable $Diagrammgrenze = 25000; wurde eingefügt, bitte in html/config_priv.php einfügen.  
+Daurch wird die Y-Achse des Diagramms in der QZ-Bilanz auf diese Größe begrenzt, um große Ausreisser
+in dem Diagramm abzufangen, die durch längeren Loggingausfall entstehen können.
 
 **[0.24.2] – 2024-08-25**  
 

--- a/CONFIG/charge.ini
+++ b/CONFIG/charge.ini
@@ -87,7 +87,7 @@ EntladeGrenze_Max = 30
 ; Nur HTTP
 ; durch das Setzen eines bestimmten Einspeisewertes unter Eigenverbrauchs-Optimierung
 ; kann über Nacht der Akku entladen werden
-; EigenverbOpt_steuern 1 = ein, 0 = aus
+; EigenverbOpt_steuern 0 = aus, 1 = ein und Tagesoptimierung nach Prognose, 2 = nachts ein und tags aus 
 EigenverbOpt_steuern = 0
 GrundlastNacht = 340
 AkkuZielProz = 40

--- a/CONFIG/charge.ini
+++ b/CONFIG/charge.ini
@@ -49,22 +49,20 @@ Akkuschonung = 1
 Zusatz_Ladebloecke = aus
 ; Zusatz_Ladebloecke = Winter, Uebergang
 
-;[Winter]
+;[Uebergang]
 ; in den Wintermonaten werden die Standardwerte aus dem Block [Ladeberechnung] durch die Nachfolgenden ersetzt
 ; Monate ist ein Schlüssel und muss im Block vorhanden sein
 ; die Monate müssen immer zweistellig sein!!
-;Monate = 11, 12, 01
-; hier Werte für den Zusatz_Ladeblock angeben
-; die Liste ist nicht abschließend und kann erweitert werden
-;BatSparFaktor = 2.0
-;MaxLadung = 5000
-;WRSchreibGrenze_nachOben = 700
-;WRSchreibGrenze_nachUnten = 1600
-;MindBattLad = 50
-
-;[Uebergang]
 ;Monate = 09, 10, 02
+;BatSparFaktor = 0.7
+;MaxLadung = 3000
+;MindBattLad = 35
+
+;[Winter]
+;Monate = 11, 12, 01
 ;BatSparFaktor = 1.0
+;MaxLadung = 5000
+;MindBattLad = 50
 
 [Reservierung]
 ; Hier kann die PV-Reserierung (z.B. für ein E-Auto nachmittags) eingeschaltet werden (1=ein, 0=aus)

--- a/FUNCTIONS/GEN24_API.py
+++ b/FUNCTIONS/GEN24_API.py
@@ -25,8 +25,8 @@ class gen24api:
             # Aktuelle Werte für Prognoseberechung
             attributes_nameplate = json.loads(data['Body']['Data']['16580608']['attributes']['nameplate'])
             # BattganzeKapazWatt * Akku_Zustand
-            Akku_Zustand = data['Body']['Data']['16580608']['channels']['BAT_VALUE_STATE_OF_HEALTH_RELATIVE_U16'] / 100
-            API['BattganzeKapazWatt'] = int(attributes_nameplate['capacity_wh'] * Akku_Zustand)
+            API['Akku_Zustand'] = data['Body']['Data']['16580608']['channels']['BAT_VALUE_STATE_OF_HEALTH_RELATIVE_U16'] / 100
+            API['BattganzeKapazWatt'] = int(attributes_nameplate['capacity_wh'] * API['Akku_Zustand'])
             API['BattganzeLadeKapazWatt'] = attributes_nameplate['max_power_charge_w']
             API['BattStatusProz'] =    round(data['Body']['Data']['16580608']['channels']['BAT_VALUE_STATE_OF_CHARGE_RELATIVE_U16'], 1)
             API['BattKapaWatt_akt'] = int((100 - API['BattStatusProz'])/100 * API['BattganzeKapazWatt']) 

--- a/FUNCTIONS/PrognoseLadewert.py
+++ b/FUNCTIONS/PrognoseLadewert.py
@@ -121,8 +121,8 @@ class progladewert:
             # Um morgens auf Null zu stellen
             org_WRSchreibGrenze_nachOben = basics.getVarConf('Ladeberechnung','WRSchreibGrenze_nachOben','eval')
             akt_prognose = self.getAktPrognose()[0]
-            if (akt_prognose < org_WRSchreibGrenze_nachOben + Grundlast and BatSparFaktor < 1):
-                LadewertGrund = "Prognose < WRSchreibGrenze_nachOben + Grundlast"
+            if (akt_prognose < Grundlast and BatSparFaktor < 1):
+                LadewertGrund = "Prognose < Grundlast"
                 aktuellerLadewert = 0
             if (aktuellerLadewert < org_WRSchreibGrenze_nachOben*0.5 and BatSparFaktor < 1):
                 LadewertGrund = "Ladewert " + str(aktuellerLadewert) + " < Grenze_nachOben/2"

--- a/FUNCTIONS/PrognoseLadewert.py
+++ b/FUNCTIONS/PrognoseLadewert.py
@@ -271,7 +271,7 @@ class progladewert:
             i  += 1
         return(Prognose_Summe, Ende_Nacht_Std)
         
-    def getEigenverbrauchOpt(self, host_ip, user, password, BattStatusProz, BattganzeKapazWatt, MaxEinspeisung=0):
+    def getEigenverbrauchOpt(self, host_ip, user, password, BattStatusProz, BattganzeKapazWatt, EigenverbOpt_steuern, MaxEinspeisung=0):
         DEBUG_Eig_opt ="\n\nDEBUG <<<<<<<< Eigenverbrauchs-Optimierung  >>>>>>>>>>>>>\n"
         GrundlastNacht = basics.getVarConf('EigenverbOptimum','GrundlastNacht','eval')
         AkkuZielProz = basics.getVarConf('EigenverbOptimum','AkkuZielProz','eval')
@@ -306,11 +306,7 @@ class progladewert:
             Eigen_Opt_Std_neu = Eigen_Opt_Std
             if BattStatusProz > AkkuZielProz:
                 if (PrognoseMorgen < PrognoseGrenzeMorgen):
-                    DEBUG_Eig_opt_tmp = "DEBUG ## >>> Bei PrognoseMorgen < PrognoseGrenzeMorgen halbe MaxEinspeisung während des Tages"
-                    DEBUG_Eig_opt_tmp += "\nDEBUG ## >>> PrognoseMorgen: " + str(PrognoseMorgen) + ", PrognoseGrenzeMorgen: " + str(PrognoseGrenzeMorgen) 
-                    Eigen_Opt_Std_neu = (MaxEinspeisung)/2
-                if (PrognoseMorgen < PrognoseGrenzeMorgen/2):
-                    DEBUG_Eig_opt_tmp = "DEBUG ## >>> Bei PrognoseMorgen < Hälfte von PrognoseGrenzeMorgen, keine Einspeisung während des Tages"
+                    DEBUG_Eig_opt_tmp = "DEBUG ## >>> Bei PrognoseMorgen < PrognoseGrenzeMorgen, keine Einspeisung während des Tages"
                     DEBUG_Eig_opt_tmp += "\nDEBUG ## >>> PrognoseMorgen: " + str(PrognoseMorgen) + ", PrognoseGrenzeMorgen: " + str(PrognoseGrenzeMorgen) 
                     Eigen_Opt_Std_neu = 0
                 if (PrognoseMorgen >= PrognoseGrenzeMorgen):
@@ -326,6 +322,13 @@ class progladewert:
                 else:
                     Eigen_Opt_Std_neu = 50
                     DEBUG_Eig_opt += "DEBUG ## >>> BattStatusProz: " + str(BattStatusProz) + ", ist kleiner als AkkuZielProz: " + str(AkkuZielProz) 
+                    DEBUG_Eig_opt += "\nDEBUG ## >>> 50 Watt während des Tages"
+
+            # Wenn EigenverbOpt_steuern 2 Optimierung ueber Tags = 0
+            if (EigenverbOpt_steuern == 2):
+                Eigen_Opt_Std_neu = 0
+                DEBUG_Eig_opt += "\nDEBUG ## >>> EigenverbOpt_steuern == 2, keine Einspeisung während des Tages"
+
     
         # Wenn Eigen_Opt_Std_arry[1] = 0, Eigenverbrauchs-Optimierung = Automatisch = 0
         if Eigen_Opt_Std_arry[1] == 0: Eigen_Opt_Std = 0

--- a/FUNCTIONS/PrognoseLadewert.py
+++ b/FUNCTIONS/PrognoseLadewert.py
@@ -109,8 +109,8 @@ class progladewert:
             if Stunden_sum < 0.1: Stunden_sum = 0.1
     
             BatSparFaktor = basics.getVarConf('Ladeberechnung','BatSparFaktor','eval')
-            aktuellerLadewert_1 = int(BattKapaWatt_akt_fun / Stunden_sum)
             # Wenn Ladewert ohne BatSparFaktor größer MaxLadung = MaxLadung, damit der Akku auch voll wird
+            aktuellerLadewert_1 = int(BattKapaWatt_akt_fun / Stunden_sum)
             if(aktuellerLadewert_1 > self.MaxLadung):
                 aktuellerLadewert = self.MaxLadung
             else:
@@ -120,11 +120,7 @@ class progladewert:
 
             # Um morgens auf Null zu stellen
             org_WRSchreibGrenze_nachOben = basics.getVarConf('Ladeberechnung','WRSchreibGrenze_nachOben','eval')
-            akt_prognose = self.getAktPrognose()[0]
-            if (akt_prognose < Grundlast and BatSparFaktor < 1):
-                LadewertGrund = "Prognose < Grundlast"
-                aktuellerLadewert = 0
-            if (aktuellerLadewert < org_WRSchreibGrenze_nachOben*0.5 and BatSparFaktor < 1):
+            if (aktuellerLadewert < org_WRSchreibGrenze_nachOben*0.7 and BatSparFaktor < 1):
                 LadewertGrund = "Ladewert " + str(aktuellerLadewert) + " < Grenze_nachOben/2"
                 aktuellerLadewert = 0
     

--- a/FUNCTIONS/PrognoseLadewert.py
+++ b/FUNCTIONS/PrognoseLadewert.py
@@ -125,6 +125,12 @@ class progladewert:
                 LadewertGrund = "Ladewert " + str(aktuellerLadewert) + " < Grenze_nachOben * 0.7"
                 aktuellerLadewert = 0
     
+            # Wenn größter Prognosewert je Stunde ist kleiner als GrenzwertGroestePrognose volle Ladung
+            GrenzwertGroestePrognose = basics.getVarConf('Ladeberechnung','GrenzwertGroestePrognose','eval')
+            if GrenzwertGroestePrognose > groestePrognose:
+                aktuellerLadewert = self.MaxLadung
+                LadewertGrund = "Größter Prognosewert " + str(groestePrognose) + " ist kleiner als GrenzwertGroestePrognose " + str(GrenzwertGroestePrognose)
+
             # Hier noch pruefen ob gesamte Prognose minus Grudlastsumme noch für Akkuladung reicht.
             # Schaltverzögerung (Hysterse)
             if (aktuellerLadewert == self.MaxLadung): Pro_Ertrag_Tag = Pro_Ertrag_Tag * 0.9
@@ -132,7 +138,7 @@ class progladewert:
                 aktuellerLadewert = self.MaxLadung
                 LadewertGrund = "TagesPrognose - Grundlast_Summe < aktuelleBattKapazität"
     
-            return int(Pro_Ertrag_Tag), Grundlast_Sum, groestePrognose, aktuellerLadewert, LadewertGrund
+            return int(Pro_Ertrag_Tag), Grundlast_Sum, aktuellerLadewert, LadewertGrund
     
     def getAktPrognose(self):
     

--- a/FUNCTIONS/PrognoseLadewert.py
+++ b/FUNCTIONS/PrognoseLadewert.py
@@ -70,8 +70,6 @@ class progladewert:
                 Prognose = Prognose_arr[0]
                 # Prognose gesamt
                 Prognose_all = Prognose_arr[1]
-                if groestePrognose < Prognose:
-                    groestePrognose = Prognose
                 Grundlast_fun = Grundlast
                 Einspeisegrenze_fun = self.Einspeisegrenze
                 Prognose_fun = Prognose
@@ -86,6 +84,9 @@ class progladewert:
                     Stunden_fun = (60-Akt_Minute)/60
     
                 Pro_Ertrag_Tag += Prognose_fun
+                # Groesste Prognose ermitteln
+                if groestePrognose < Prognose_fun:
+                    groestePrognose = Prognose_fun
     
                 # Alles über WR_Kapazitaet bzw. Einspeisegrenze von BattKapaWatt_akt abziehen,
                 # da dies nicht für die Prognoseberechnung zur Verfügung steht.
@@ -121,11 +122,13 @@ class progladewert:
             # Um morgens auf Null zu stellen
             org_WRSchreibGrenze_nachOben = basics.getVarConf('Ladeberechnung','WRSchreibGrenze_nachOben','eval')
             if (aktuellerLadewert < org_WRSchreibGrenze_nachOben*0.7 and BatSparFaktor < 1):
-                LadewertGrund = "Ladewert " + str(aktuellerLadewert) + " < Grenze_nachOben/2"
+                LadewertGrund = "Ladewert " + str(aktuellerLadewert) + " < Grenze_nachOben * 0.7"
                 aktuellerLadewert = 0
     
             # Hier noch pruefen ob gesamte Prognose minus Grudlastsumme noch für Akkuladung reicht.
-            if((aktuellerLadewert <= self.MaxLadung) and ((Pro_Ertrag_Tag - Grundlast_Sum) / 1.1) < BattKapaWatt_akt_fun):
+            # Schaltverzögerung (Hysterse)
+            if (aktuellerLadewert == self.MaxLadung): Pro_Ertrag_Tag = Pro_Ertrag_Tag * 0.9
+            if(((Pro_Ertrag_Tag - Grundlast_Sum) / 1.1) < self.BattKapaWatt_akt):
                 aktuellerLadewert = self.MaxLadung
                 LadewertGrund = "TagesPrognose - Grundlast_Summe < aktuelleBattKapazität"
     

--- a/SymoGen24Controller2.py
+++ b/SymoGen24Controller2.py
@@ -132,7 +132,7 @@ if __name__ == '__main__':
                             reservierungdata[key] = Res_Feld
 
                     # 0 = nicht auf WR schreiben, 1 = auf WR schreiben
-                    newPercent_schreiben = 0
+                    WR_schreiben = 0
                     oldPercent = gen24.read_data('BatteryMaxChargePercent')
                     alterLadewert = int(oldPercent*BattganzeLadeKapazWatt/10000)
     
@@ -143,10 +143,8 @@ if __name__ == '__main__':
                     ## Ab hier geht die Berechnung los
                     #######################################
     
-                    TagesPrognoseUeberschuss = 0
                     TagesPrognoseGesamt = 0
                     aktuellerLadewert = 0
-                    PrognoseUberschuss = 0
                     Grundlast_Summe = 0
                     aktuelleVorhersage = 0
                     LadewertGrund = ""
@@ -170,15 +168,14 @@ if __name__ == '__main__':
                         BattVollUm = BattVollUm - 1
 
 
-                    # Geamtprognose und Ladewert berechnen mit Funktion getRestTagesPrognoseUeberschuss
-                    PrognoseUNDUeberschuss = progladewert.getRestTagesPrognoseUeberschuss(BattVollUm, Grundlast)
-                    TagesPrognoseUeberschuss = PrognoseUNDUeberschuss[0]
-                    TagesPrognoseGesamt = PrognoseUNDUeberschuss[1]
-                    PrognoseUberschuss = PrognoseUNDUeberschuss[2]
-                    Grundlast_Summe = PrognoseUNDUeberschuss[3]
-                    GroestePrognose = PrognoseUNDUeberschuss[4]
-                    aktuellerLadewert = PrognoseUNDUeberschuss[5]
-                    LadewertGrund = PrognoseUNDUeberschuss[6]
+                    # Geamtprognose und Ladewert berechnen mit Funktion getLadewert
+                    PrognoseUNDUeberschuss = progladewert.getLadewert(BattVollUm, Grundlast)
+                    TagesPrognoseGesamt = PrognoseUNDUeberschuss[0]
+                    Grundlast_Summe = PrognoseUNDUeberschuss[1]
+                    GroestePrognose = PrognoseUNDUeberschuss[2]
+                    aktuellerLadewert = PrognoseUNDUeberschuss[3]
+                    LadewertGrund = PrognoseUNDUeberschuss[4]
+
                     # Einspeisebegrenzung prüfen
                     Einspeisegrenze = progladewert.getEinspeiseGrenzeLadewert(WRSchreibGrenze_nachOben, aktuellerLadewert, aktuelleEinspeisung, aktuellePVProduktion, LadewertGrund, alterLadewert, PV_Leistung_Watt)
                     aktuellerLadewert = Einspeisegrenze[0]
@@ -189,14 +186,17 @@ if __name__ == '__main__':
                     aktuellerLadewert = ACKapazitaet[0]
                     LadewertGrund = ACKapazitaet[1]
 
+                    # ladewert in Prozent
+                    DATA = progladewert.setLadewert(aktuellerLadewert, WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten, BattganzeLadeKapazWatt, alterLadewert)
+                    newPercent = DATA[0]
+                    WR_schreiben = DATA[1]
 
                     # Aktuelle Prognose berechnen
-                    AktuellenLadewert_Array = progladewert.getPrognoseLadewert()
+                    AktuellenLadewert_Array = progladewert.getAktPrognose()
                     aktuelleVorhersage = AktuellenLadewert_Array[0]
                     DEBUG_Ausgabe = AktuellenLadewert_Array[1]
 
                     # DEBUG_Ausgabe der Ladewertermittlung 
-                    DEBUG_Ausgabe += "\nDEBUG TagesPrognoseUeberschuss: " + str(TagesPrognoseUeberschuss) + ", Grundlast: " + str(Grundlast)
                     DEBUG_Ausgabe += ", aktuellerLadewert: " + str(aktuellerLadewert) + "\n"
 
 
@@ -209,26 +209,26 @@ if __name__ == '__main__':
 
                     # Wenn die Variable "FesteLadeleistung" größer "0" ist, wird der Wert fest als Ladeleistung in Watt geschrieben einstellbare Wattzahl
                     if FesteLadeleistung >= 0:
-                        DATA = progladewert.setLadewert(FesteLadeleistung, WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten, BattganzeLadeKapazWatt, oldPercent)
+                        DATA = progladewert.setLadewert(FesteLadeleistung, WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten, BattganzeLadeKapazWatt, alterLadewert)
                         aktuellerLadewert = FesteLadeleistung
                         newPercent = DATA[0]
                         # wegen Rundung
                         if abs(newPercent - oldPercent) < 3:
-                            newPercent_schreiben = 0
+                            WR_schreiben = 0
                         else:
-                            newPercent_schreiben = 1
+                            WR_schreiben = 1
                         if MaxladungDurchPV_Planung == "":
                             LadewertGrund = "FesteLadeleistung"
                         else:
                             LadewertGrund = MaxladungDurchPV_Planung
     
-                    # Hier Volle Ladung, wenn BattVollUm erreicht ist!
-                    elif (int(datetime.strftime(now, "%H")) >= int(BattVollUm)):
+                    # Hier Volle Ladung, wenn BattVollUm erreicht ist oder Akku = 100%!
+                    elif (int(datetime.strftime(now, "%H")) >= int(BattVollUm)) or (BattStatusProz == 100):
                          aktuellerLadewert = MaxLadung
-                         DATA = progladewert.setLadewert(aktuellerLadewert, WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten, BattganzeLadeKapazWatt, oldPercent)
+                         DATA = progladewert.setLadewert(aktuellerLadewert, WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten, BattganzeLadeKapazWatt, alterLadewert)
                          newPercent = DATA[0]
-                         newPercent_schreiben = DATA[1]
-                         LadewertGrund = "BattVollUm erreicht!!"
+                         WR_schreiben = DATA[1]
+                         LadewertGrund = "BattVollUm oder Akkustand 100% erreicht!"
         
                     else:
 
@@ -239,53 +239,17 @@ if __name__ == '__main__':
                         if ((BattStatusProz < MindBattLad)):
                             # volle Ladung ;-)
                             aktuellerLadewert = MaxLadung
-                            DATA = progladewert.setLadewert(aktuellerLadewert, WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten, BattganzeLadeKapazWatt, oldPercent)
+                            DATA = progladewert.setLadewert(aktuellerLadewert, WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten, BattganzeLadeKapazWatt, alterLadewert)
                             newPercent = DATA[0]
-                            newPercent_schreiben = DATA[1]
+                            WR_schreiben = DATA[1]
                             LadewertGrund = "BattStatusProz < MindBattLad"
     
-                        else:
-    
-                            TagesPrognoseGesamt_tmp = TagesPrognoseGesamt + aktuelleVorhersage
-                            if (TagesPrognoseGesamt_tmp > Grundlast) and ((TagesPrognoseGesamt_tmp - Grundlast_Summe) < BattKapaWatt_akt):
-                                # volle Ladung ;-)
-                                aktuellerLadewert = MaxLadung
-                                DATA = progladewert.setLadewert(aktuellerLadewert, WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten, BattganzeLadeKapazWatt, oldPercent)
-                                newPercent = DATA[0]
-                                newPercent_schreiben = DATA[1]
-                                LadewertGrund = "TagesPrognose+aktuellePrognose-Grundlast_Summe < BattKapaWatt_akt"
-    
-                            # PrognoseUberschuss - 100 um Schaltverzögerung wieder nach unten zu erreichen
-                            elif (TagesPrognoseUeberschuss < BattKapaWatt_akt) and (PrognoseUberschuss - 100 <= Grundlast):
-                                # Auch hier die Schaltverzögerung anbringen und dann MaxLadung, also immer nach oben.
-                                if BattKapaWatt_akt - TagesPrognoseUeberschuss < WRSchreibGrenze_nachOben:
-                                    # Nach Prognoseberechnung darf es trotzdem nach oben gehen aber nicht von MaxLadung nach unten !
-                                    WRSchreibGrenze_nachUnten = 100000
-                                    DATA = progladewert.setLadewert(aktuellerLadewert, WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten, BattganzeLadeKapazWatt, oldPercent)
-                                    newPercent = DATA[0]
-                                    newPercent_schreiben = DATA[1]
-                                    # Nur wenn newPercent_schreiben = 0 dann LadewertGrund mit Hinweis übreschreiben
-                                    if newPercent_schreiben == 0:
-                                        LadewertGrund = "PrognoseUberschuss nahe Grundlast (Unterschied weniger als Schreibgrenze)"
-                                else:
-                                    # volle Ladung ;-)
-                                    aktuellerLadewert = MaxLadung
-                                    DATA = progladewert.setLadewert(aktuellerLadewert, WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten, BattganzeLadeKapazWatt, oldPercent)
-                                    newPercent = DATA[0]
-                                    newPercent_schreiben = DATA[1]
-                                    LadewertGrund = "PrognoseUberschuss kleiner Grundlast und Schreibgrenze"
-
-                            else: 
-                                DATA = progladewert.setLadewert(aktuellerLadewert, WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten, BattganzeLadeKapazWatt, oldPercent)
-                                newPercent = DATA[0]
-                                newPercent_schreiben = DATA[1]
-
                         # Wenn größter Prognosewert je Stunde ist kleiner als GrenzwertGroestePrognose volle Ladung
                         if GrenzwertGroestePrognose > GroestePrognose:
                             aktuellerLadewert = MaxLadung
-                            DATA = progladewert.setLadewert(aktuellerLadewert, WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten, BattganzeLadeKapazWatt, oldPercent)
+                            DATA = progladewert.setLadewert(aktuellerLadewert, WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten, BattganzeLadeKapazWatt, alterLadewert)
                             newPercent = DATA[0]
-                            newPercent_schreiben = DATA[1]
+                            WR_schreiben = DATA[1]
                             LadewertGrund = "Größter Prognosewert " + str(GroestePrognose) + " ist kleiner als GrenzwertGroestePrognose " + str(GrenzwertGroestePrognose)
 
                     # Wenn Akkuschonung > 0 ab 80% Batterieladung mit Ladewert runter fahren
@@ -294,20 +258,20 @@ if __name__ == '__main__':
                         Ladefaktor = 1
                         BattStatusProz_Grenze = 100
                         # Schaltverzoegerung neu 
-                        if (BattStatusProz >= 78 and ( abs((BattganzeKapazWatt * 0.2) - alterLadewert) < 3 )) or BattStatusProz >= 80:
+                        if (BattStatusProz >= 78 and ( abs((BattganzeLadeKapazWatt * 0.2) - alterLadewert) < 3 )) or BattStatusProz >= 80:
                             Ladefaktor = 0.2
                             AkkuSchonGrund = '80%, Ladewert = 0.2C'
                             BattStatusProz_Grenze = 80
-                        if (BattStatusProz >= 88 and ( abs((BattganzeKapazWatt * 0.1) - alterLadewert) < 3 )) or BattStatusProz >= 90:
+                        if (BattStatusProz >= 88 and ( abs((BattganzeLadeKapazWatt * 0.1) - alterLadewert) < 3 )) or BattStatusProz >= 90:
                             Ladefaktor = 0.1
                             AkkuSchonGrund = '90%, Ladewert = 0.1C'
                             BattStatusProz_Grenze = 90
-                        if (BattStatusProz >= 94 and ( abs((BattganzeKapazWatt * 0.1* Akkuschonung) - alterLadewert) < 3 )) or BattStatusProz >= 95:
+                        if (BattStatusProz >= 94 and ( abs((BattganzeLadeKapazWatt * 0.1* Akkuschonung) - alterLadewert) < 3 )) or BattStatusProz >= 95:
                             Ladefaktor = 0.1 * Akkuschonung
                             AkkuSchonGrund = '95%, Ladewert = ' + str(Ladefaktor) + 'C'
                             BattStatusProz_Grenze = 95
 
-                        AkkuschonungLadewert = int(BattganzeKapazWatt * Ladefaktor)
+                        AkkuschonungLadewert = int(BattganzeLadeKapazWatt * Ladefaktor)
                         # Bei Akkuschonung Schaltverzögerung (hysterese), wenn Ladewert ist bereits der Akkuschonwert (+/- 3W) BattStatusProz_Grenze 5% runter
                         if ( abs(AkkuschonungLadewert - alterLadewert) < 3 ):
                             BattStatusProz_Grenze = BattStatusProz_Grenze * 0.95
@@ -324,9 +288,9 @@ if __name__ == '__main__':
                                 aktuellerLadewert = AkkuschonungLadewert
                                 WRSchreibGrenze_nachUnten = aktuellerLadewert / 5
                                 WRSchreibGrenze_nachOben = aktuellerLadewert / 5
-                                DATA = progladewert.setLadewert(aktuellerLadewert, WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten, BattganzeLadeKapazWatt, oldPercent)
+                                DATA = progladewert.setLadewert(aktuellerLadewert, WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten, BattganzeLadeKapazWatt, alterLadewert)
                                 newPercent = DATA[0]
-                                newPercent_schreiben = DATA[1]
+                                WR_schreiben = DATA[1]
                                 LadewertGrund = "Akkuschonung: Ladestand >= " + AkkuSchonGrund
 
                     # Wenn die aktuellePVProduktion < 10 Watt ist, nicht schreiben, 
@@ -336,12 +300,12 @@ if __name__ == '__main__':
                         # da sonst mogends evtl nicht auf 0 gestelltwerden kann, wegen WRSchreibGrenze_nachUnten
                         if alterLadewert < MaxLadung -10 :
                             aktuellerLadewert = MaxLadung
-                            DATA = progladewert.setLadewert(aktuellerLadewert, WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten, BattganzeLadeKapazWatt, oldPercent)
+                            DATA = progladewert.setLadewert(aktuellerLadewert, WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten, BattganzeLadeKapazWatt, alterLadewert)
                             newPercent = DATA[0]
-                            newPercent_schreiben = DATA[1]
+                            WR_schreiben = DATA[1]
                             LadewertGrund = "Auf MaxLadung stellen, da PVProduktion < 10 Watt!"
                         else:
-                            newPercent_schreiben = 0
+                            WR_schreiben = 0
                             LadewertGrund = "Nicht schreiben, da PVProduktion < 10 Watt!"
 
                     # Auf ganze Watt runden
@@ -354,7 +318,6 @@ if __name__ == '__main__':
                             if(Ausgabe_Parameter != ''): print(Ausgabe_Parameter)
                             print("aktuellePrognose:           ", aktuelleVorhersage)
                             print("TagesPrognose - BattVollUm: ", TagesPrognoseGesamt,"-", BattVollUm)
-                            print("PrognoseUberschuss/Stunde:  ", PrognoseUberschuss)
                             print("Grundlast_Summe für Tag:    ", Grundlast_Summe)
                             print("aktuellePVProduktion/Watt:  ", aktuellePVProduktion)
                             print("aktuelleEinspeisung/Watt:   ", aktuelleEinspeisung)
@@ -383,8 +346,8 @@ if __name__ == '__main__':
                     bereits_geschrieben = 0
                     Schreib_Ausgabe = ""
                     Push_Schreib_Ausgabe = ""
-                    # Neuen Ladewert in Prozent schreiben, wenn newPercent_schreiben == 1
-                    if newPercent_schreiben == 1:
+                    # Neuen Ladewert in Prozent schreiben, wenn WR_schreiben == 1
+                    if WR_schreiben == 1:
                         DEBUG_Ausgabe+="\nDEBUG <<<<<<<< LADEWERTE >>>>>>>>>>>>>"
                         DEBUG_Ausgabe+="\nDEBUG Folgender Ladewert neu zum Schreiben: " + str(newPercent)
                         if ('laden' in Options):

--- a/SymoGen24Controller2.py
+++ b/SymoGen24Controller2.py
@@ -313,6 +313,7 @@ if __name__ == '__main__':
                             print("aktuelleEinspeisung/Watt:   ", aktuelleEinspeisung)
                             print("aktuelleBatteriePower/Watt: ", aktuelleBatteriePower)
                             print("GesamtverbrauchHaus/Watt:   ", GesamtverbrauchHaus)
+                            print("Akku_Zustand in Prozent:    ", API['Akku_Zustand']*100,"%")
                             print("aktuelleBattKapazität/Watt: ", BattKapaWatt_akt)
                             print("Batteriestatus in Prozent:  ", BattStatusProz,"%")
                             print("LadewertGrund: ", LadewertGrund)

--- a/SymoGen24Controller2.py
+++ b/SymoGen24Controller2.py
@@ -72,7 +72,6 @@ if __name__ == '__main__':
                     PV_Leistung_Watt = basics.getVarConf('Ladeberechnung','PV_Leistung_Watt','eval')
                     Grundlast = basics.getVarConf('Ladeberechnung','Grundlast','eval')
                     MindBattLad = basics.getVarConf('Ladeberechnung','MindBattLad','eval')
-                    GrenzwertGroestePrognose = basics.getVarConf('Ladeberechnung','GrenzwertGroestePrognose','eval')
                     WRSchreibGrenze_nachOben = basics.getVarConf('Ladeberechnung','WRSchreibGrenze_nachOben','eval')
                     WRSchreibGrenze_nachUnten = basics.getVarConf('Ladeberechnung','WRSchreibGrenze_nachUnten','eval')
                     FesteLadeleistung = basics.getVarConf('Ladeberechnung','FesteLadeleistung','eval')
@@ -172,9 +171,8 @@ if __name__ == '__main__':
                     PrognoseUNDUeberschuss = progladewert.getLadewert(BattVollUm, Grundlast)
                     TagesPrognoseGesamt = PrognoseUNDUeberschuss[0]
                     Grundlast_Summe = PrognoseUNDUeberschuss[1]
-                    GroestePrognose = PrognoseUNDUeberschuss[2]
-                    aktuellerLadewert = PrognoseUNDUeberschuss[3]
-                    LadewertGrund = PrognoseUNDUeberschuss[4]
+                    aktuellerLadewert = PrognoseUNDUeberschuss[2]
+                    LadewertGrund = PrognoseUNDUeberschuss[3]
 
                     # Einspeisebegrenzung prüfen
                     Einspeisegrenze = progladewert.getEinspeiseGrenzeLadewert(WRSchreibGrenze_nachOben, aktuellerLadewert, aktuelleEinspeisung, aktuellePVProduktion, LadewertGrund, alterLadewert, PV_Leistung_Watt)
@@ -207,7 +205,7 @@ if __name__ == '__main__':
                         FesteLadeleistung = BattganzeLadeKapazWatt * ManuelleSteuerung/100
                         MaxladungDurchPV_Planung = "Manuelle Ladesteuerung in PV-Planung ausgewählt."
 
-                    # Wenn die Variable "FesteLadeleistung" größer "0" ist, wird der Wert fest als Ladeleistung in Watt geschrieben einstellbare Wattzahl
+                    # Wenn die Variable "FesteLadeleistung" größergleich "0" ist, wird der Wert fest als Ladeleistung geschrieben
                     if FesteLadeleistung >= 0:
                         DATA = progladewert.setLadewert(FesteLadeleistung, WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten, BattganzeLadeKapazWatt, alterLadewert)
                         aktuellerLadewert = FesteLadeleistung
@@ -244,14 +242,6 @@ if __name__ == '__main__':
                             WR_schreiben = DATA[1]
                             LadewertGrund = "BattStatusProz < MindBattLad"
     
-                        # Wenn größter Prognosewert je Stunde ist kleiner als GrenzwertGroestePrognose volle Ladung
-                        if GrenzwertGroestePrognose > GroestePrognose:
-                            aktuellerLadewert = MaxLadung
-                            DATA = progladewert.setLadewert(aktuellerLadewert, WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten, BattganzeLadeKapazWatt, alterLadewert)
-                            newPercent = DATA[0]
-                            WR_schreiben = DATA[1]
-                            LadewertGrund = "Größter Prognosewert " + str(GroestePrognose) + " ist kleiner als GrenzwertGroestePrognose " + str(GrenzwertGroestePrognose)
-
                     # Wenn Akkuschonung > 0 ab 80% Batterieladung mit Ladewert runter fahren
                     HysteProdFakt = 2
                     if Akkuschonung > 0:

--- a/html/4_Hilfe.html
+++ b/html/4_Hilfe.html
@@ -255,7 +255,7 @@ td {font-size: 160%;
 <tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[96]" value='' >; Nur HTTP</td></tr>
 <tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[97]" value='' >; durch das Setzen eines bestimmten Einspeisewertes unter Eigenverbrauchs-Optimierung</td></tr>
 <tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[98]" value='' >; kann über Nacht der Akku entladen werden</td></tr>
-<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[99]" value='' >; EigenverbOpt_steuern 1 = ein, 0 = aus</td></tr>
+<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[99]" value='' >; EigenverbOpt_steuern 0 = aus, 1 = ein und Tagesoptimierung nach Prognose, 2 = nachts ein und tags aus.</td></tr>
 <tr><td><input type="hidden" name="Zeile[100][0]" value=''>EigenverbOpt_steuern</td>
 <td><input type="text" name="Zeile[100][1]" value="1" readonly></td></tr>
 <tr><td><input type="hidden" name="Zeile[101][0]" value=''>GrundlastNacht</td>

--- a/html/4_Hilfe.html
+++ b/html/4_Hilfe.html
@@ -92,6 +92,7 @@ td {font-size: 160%;
 <td><input type="text" name="Zeile[12][1]" value="192.168.178.50" readonly></td></tr>
 <tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[13]" value='' >; hier können die IPs weiterer GEN24  bzw. Symos, durch Komma getrennt, stehen. no = kein weiterer GEN24</td></tr>
 <tr><td><input type="hidden" name="Zeile[14][0]" value=''>IP_weitere_Gen24</td>
+<td><input type="text" name="Zeile[14][1]" value="no" readonly></td></tr>
 <tr><td><input type="hidden" name="Zeile[14][1]" value=''>IP_weitere_Symo</td>
 <td><input type="text" name="Zeile[14][1]" value="no" readonly></td></tr>
 <tr><td><input type="hidden" name="Zeile[15][0]" value=''>port</td>

--- a/html/4_Hilfe.html
+++ b/html/4_Hilfe.html
@@ -150,7 +150,12 @@ td {font-size: 160%;
 <tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[16]" value='' >; Größter Batterieladewert, der im WR gesetzt werden soll, aber höchstens der maximale mögliche Ladewert!!!</td></tr>
 <tr><td><input type="hidden" name="Zeile[17][0]" value=''>MaxLadung</td>
 <td><input type="text" name="Zeile[17][1]" value="3000" readonly></td></tr>
-<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[18]" value='' >; die Einspeisegrenze sollte etwas unterhalb der wirklichen Grenze liegen (1-2%).</td></tr>
+<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[18]" value='' >; die Einspeisegrenze sollte etwas unterhalb der wirklichen Grenze liegen (1-2%), nur in der Modbus-Version.<br>
+;In der HTTP-Version wird sie nicht mehr zur Einspeisebegrenzung verwendet, da der WR dies selber macht. <br>
+;Der Wert wird aber verwendet, um die Batteriekapazität für die Energie über der Einspeisegrenze zu reservieren. <br>
+;Wenn man die Grenze etwas heruntersetzt, reserviert er an schönen Tagen mehr Batteriekapazität für Mittag, und lädt morgens weniger.<br>
+;Damit kann man die Ladung noch mehr gegen Mittag verschieben.
+</td></tr>
 <tr><td><input type="hidden" name="Zeile[19][0]" value=''>Einspeisegrenze</td>
 <td><input type="text" name="Zeile[19][1]" value="8000" readonly></td></tr>
 <tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[20]" value='' >; AC Kapazität des Wechselrichters um den Überschuss in die Batterie zu laden (etwas darunter bleiben 1-2%)</td></tr>

--- a/html/4_tab_config_ini.php
+++ b/html/4_tab_config_ini.php
@@ -65,7 +65,7 @@ td {font-size: 160%;
 <body>
   <div class="hilfe"> <a href="4_Hilfe.html"><b>Hilfe</b></a></div>
 <div class="version" align="center">
-<b>  GEN24_Ladesteuerung Version: 0.24.2 </b>
+<b>  GEN24_Ladesteuerung Version: 0.24.3 </b>
 </div>
 <br>
 <?php

--- a/html/8_funktion_Diagram.php
+++ b/html/8_funktion_Diagram.php
@@ -345,7 +345,7 @@ window.onload = function() { zeitsetzer(1); };
 ";
 } # END function Optionenausgabe
 
-function Diagram_ausgabe($Footer, $Diatype, $labels, $daten, $optionen, $EnergieEinheit)
+function Diagram_ausgabe($Footer, $Diatype, $labels, $daten, $optionen, $EnergieEinheit, $Diagrammgrenze)
 {
 $Nachkommastellen = 2;
 if ($EnergieEinheit == 'W') $Nachkommastellen = 0;
@@ -472,11 +472,11 @@ echo "    }]
         },
         // Hier die Scala auf X-Wert begrenzen
         afterDataLimits(scale) {
-          if(scale.max > 15000) {
-          scale.max = 15000;
+          if(scale.max > ".$Diagrammgrenze.") {
+          scale.max = ".$Diagrammgrenze.";
           }
-          if(scale.min < -15000) {
-          scale.min = -15000;
+          if(scale.min < -".$Diagrammgrenze.") {
+          scale.min = -".$Diagrammgrenze.";
           }
         }
       },

--- a/html/8_funktion_Diagram.php
+++ b/html/8_funktion_Diagram.php
@@ -469,6 +469,15 @@ echo "    }]
            font: {
              size: 20,
            }
+        },
+        // Hier die Scala auf X-Wert begrenzen
+        afterDataLimits(scale) {
+          if(scale.max > 15000) {
+          scale.max = 15000;
+          }
+          if(scale.min < -15000) {
+          scale.min = -15000;
+          }
         }
       },
       y2: {

--- a/html/8_tab_Diagram.php
+++ b/html/8_tab_Diagram.php
@@ -151,7 +151,7 @@ if ($diagramtype == 'line') {
     echo "<div class='container'>
         <canvas id='PVDaten' style='height:100vh; width:100vw'></canvas>
     </div>";
-Diagram_ausgabe($Footer, 'line', $labels, $daten, $optionen, 'W');
+Diagram_ausgabe($Footer, 'line', $labels, $daten, $optionen, 'W', $Diagrammgrenze);
 } else {  # Dann bar = Balkendiagramm
 
     # Funktion Schalter aufrufen
@@ -169,7 +169,7 @@ Diagram_ausgabe($Footer, 'line', $labels, $daten, $optionen, 'W');
     echo "<div class='container'>
         <canvas id='PVDaten' style='height:100vh; width:100vw'></canvas>
     </div>";
-    Diagram_ausgabe($Footer, 'bar', $labels, $daten, $optionen, 'KW');
+    Diagram_ausgabe($Footer, 'bar', $labels, $daten, $optionen, 'KW', $Diagrammgrenze);
 
 } # END if ($diagramtype == 
     $db->close();

--- a/html/config.php
+++ b/html/config.php
@@ -8,6 +8,7 @@ if(file_exists("../CONFIG/default_priv.ini")){
 $PrognoseFile = "../weatherData.json";
 $PV_Leistung_KWp = 11.4;
 $Faktor_PVLeistung_Prognose = 1.00;
+$Diagrammgrenze = 25000;
 $Res_Feld1 = "EV_1";
 $Res_Feld2 = "EV_2";
 $passwd_configedit = "0815";

--- a/http_SymoGen24Controller2.py
+++ b/http_SymoGen24Controller2.py
@@ -73,7 +73,6 @@ if __name__ == '__main__':
                     PV_Leistung_Watt = basics.getVarConf('Ladeberechnung','PV_Leistung_Watt','eval')
                     Grundlast = basics.getVarConf('Ladeberechnung','Grundlast','eval')
                     MindBattLad = basics.getVarConf('Ladeberechnung','MindBattLad','eval')
-                    GrenzwertGroestePrognose = basics.getVarConf('Ladeberechnung','GrenzwertGroestePrognose','eval')
                     WRSchreibGrenze_nachOben = basics.getVarConf('Ladeberechnung','WRSchreibGrenze_nachOben','eval')
                     WRSchreibGrenze_nachUnten = basics.getVarConf('Ladeberechnung','WRSchreibGrenze_nachUnten','eval')
                     FesteLadeleistung = basics.getVarConf('Ladeberechnung','FesteLadeleistung','eval')
@@ -175,9 +174,8 @@ if __name__ == '__main__':
                     PrognoseUNDUeberschuss = progladewert.getLadewert(BattVollUm, Grundlast)
                     TagesPrognoseGesamt = PrognoseUNDUeberschuss[0]
                     Grundlast_Summe = PrognoseUNDUeberschuss[1]
-                    GroestePrognose = PrognoseUNDUeberschuss[2]
-                    aktuellerLadewert = PrognoseUNDUeberschuss[3]
-                    LadewertGrund = PrognoseUNDUeberschuss[4]
+                    aktuellerLadewert = PrognoseUNDUeberschuss[2]
+                    LadewertGrund = PrognoseUNDUeberschuss[3]
                     # Ladewert auf Schreibgrenzen prüfen
                     DATA = progladewert.setLadewert(aktuellerLadewert, WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten, BattganzeLadeKapazWatt, alterLadewert)
                     WR_schreiben = DATA[1]
@@ -232,13 +230,6 @@ if __name__ == '__main__':
                             WR_schreiben = DATA[1]
                             LadewertGrund = "BattStatusProz < MindBattLad"
     
-                        # Wenn größter Prognosewert je Stunde ist kleiner als GrenzwertGroestePrognose volle Ladung
-                        if GrenzwertGroestePrognose > GroestePrognose:
-                            aktuellerLadewert = MaxLadung
-                            DATA = progladewert.setLadewert(aktuellerLadewert, WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten, BattganzeLadeKapazWatt, alterLadewert)
-                            WR_schreiben = DATA[1]
-                            LadewertGrund = "Größter Prognosewert " + str(GroestePrognose) + " ist kleiner als GrenzwertGroestePrognose " + str(GrenzwertGroestePrognose)
-
                     # Wenn Akkuschonung > 0 ab 80% Batterieladung mit Ladewert runter fahren
                     HysteProdFakt = 2
                     if Akkuschonung > 0:

--- a/http_SymoGen24Controller2.py
+++ b/http_SymoGen24Controller2.py
@@ -432,8 +432,8 @@ if __name__ == '__main__':
                     ######## WR Batteriemanagement ENDE
 
                     ######## Eigenverbrauchs-Optimierung  ab hier wenn eingeschaltet!
-                    if  EigenverbOpt_steuern == 1:
-                        EigenOptERG = progladewert.getEigenverbrauchOpt(host_ip, user, password, BattStatusProz, BattganzeKapazWatt, MaxEinspeisung)
+                    if  EigenverbOpt_steuern > 0:
+                        EigenOptERG = progladewert.getEigenverbrauchOpt(host_ip, user, password, BattStatusProz, BattganzeKapazWatt, EigenverbOpt_steuern, MaxEinspeisung)
                         PrognoseMorgen = EigenOptERG[0]
                         Eigen_Opt_Std = EigenOptERG[1]
                         Eigen_Opt_Std_neu = EigenOptERG[2]

--- a/http_SymoGen24Controller2.py
+++ b/http_SymoGen24Controller2.py
@@ -299,6 +299,7 @@ if __name__ == '__main__':
                             print("aktuelleEinspeisung/Watt:   ", aktuelleEinspeisung)
                             print("aktuelleBatteriePower/Watt: ", aktuelleBatteriePower)
                             print("GesamtverbrauchHaus/Watt:   ", GesamtverbrauchHaus)
+                            print("Akku_Zustand in Prozent:    ", API['Akku_Zustand']*100,"%")
                             print("aktuelleBattKapazität/Watt: ", BattKapaWatt_akt)
                             print("Batteriestatus in Prozent:  ", BattStatusProz,"%")
                             print("LadewertGrund: ", LadewertGrund)


### PR DESCRIPTION
Vereinfachung des Programmcodes zur Ermittlung des Ladewertes

**Neuerungen bei Ladewertberechnung**

Bei BatSparFaktor < 1 wird morgens bei folgenden Bedingungen die Ladung auf 0 gestellt:
Prognoseladewert < Grenze_nachOben*0.7"

Wenn Ladewert ohne BatSparFaktor größer MaxLadung = MaxLadung, damit der Akku auch voll wird

