### PR TITLE
Jahreszeitenabhänginge Konfiguration in zusätzliche config-files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 **[0.24.4] – 2024-XX-XX**  
 
-Auslagerung der jahrezeitenabhängingen Konfiguration in zusätzliche config-files  
+Auslagerung der jahreszeitenabhängingen Konfiguration in zusätzliche config-files  
 
 #### ACHTUNG Änderung in der CONFIG/charge.ini und charge_priv.ini:  
 - Definition der Zusatz_Ladebloecke und Zeilen mit Zusatz_Ladebloecke **entfernt**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Auslagerung der jahreszeitenabhängingen Konfiguration in zusätzliche config-files  
 Vorteil: Man kann dort alle Definitionen, die in der charge.ini, bzw. charge_priv.ini enthalten sind, 
-Monats abhängig ändern. Nicht nur aus dem Block [Ladeberechnung], sondern auch z.B. aus `[Entladung]`, `[EigenverbOptimum]` usw.
+Monats abhängig machen. Nicht nur aus dem Block [Ladeberechnung], sondern auch z.B. aus `[Entladung]`oder `[EigenverbOptimum]`.
 
 
 #### ACHTUNG Änderung in der CONFIG/charge.ini und charge_priv.ini:  
@@ -11,7 +11,7 @@ Monats abhängig ändern. Nicht nur aus dem Block [Ladeberechnung], sondern auch
   Beispielconfig winter_priv.ini = 11, 12, 01 eingefügt und Protofile winter.ini eingefügt.
 
 Aktivieren z.B. in CONFIG/charge_priv.ini  
-- Kommentar entfernen und winter.ini nach winter_priv.ini umbenennen.
+- Kommentar bei `winter_priv.ini = 11, 12, 01` entfernen und winter.ini nach winter_priv.ini umbenennen, und enthaltene Werte anpassen.
 
 **[0.24.3] – 2024-09-01**  
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 **[0.24.4] – 2024-XX-XX**  
 
+Auslagerung der jahrezeitenabhängingen Konfiguration in zusätzliche config-files  
+
+#### ACHTUNG Änderung in der CONFIG/charge.ini und charge_priv.ini:  
+- Definition der Zusatz_Ladebloecke und Zeilen mit Zusatz_Ladebloecke **entfernt**.
+- Neuen Block [monats_priv.ini] eingefügt, hier zusätzliche config-files mit Monaten eintragen  
+  Beispielconfig winter_priv.ini = 11, 12, 01 eingefügt und Protofile winter.ini eingefügt.
+
+Aktivieren z.B. in CONFIG/charge_priv.ini  
+- Kommentar entfernen und winter.ini nach winter_priv.ini umbenennen.
 
 **[0.24.3] – 2024-09-01**  
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-**[0.24.4] – 2024-XX-XX**  
+**[0.24.4] – 2024-09-08**  
 
 Auslagerung der jahreszeitenabhängingen Konfiguration in zusätzliche config-files  
+Vorteil: Man kann dort alle Definitionen, die in der charge.ini, bzw. charge_priv.ini enthalten sind, 
+Monats abhängig ändern. Nicht nur aus dem Block [Ladeberechnung], sondern auch z.B. aus `[Entladung]`, `[EigenverbOptimum]` usw.
+
 
 #### ACHTUNG Änderung in der CONFIG/charge.ini und charge_priv.ini:  
 - Definition der Zusatz_Ladebloecke und Zeilen mit Zusatz_Ladebloecke **entfernt**.

--- a/CONFIG/charge.ini
+++ b/CONFIG/charge.ini
@@ -44,25 +44,11 @@ GrenzwertGroestePrognose = 2000
 ; ACHTUNG: Eine Überschreitung der Einspeisegrenze bzw. AC-Leistung des WR setzt die Akkuschonung aus!
 Akkuschonung = 1
 
-; hier müssen die Namen der zusätzlichen Konfigurationen definiert werden.
-; mit Zusatz_Ladebloecke = aus können die zusätzlichen Konfigurationen abgeschaltet werden
-Zusatz_Ladebloecke = aus
-; Zusatz_Ladebloecke = Winter, Uebergang
-
-;[Uebergang]
-; in den Wintermonaten werden die Standardwerte aus dem Block [Ladeberechnung] durch die Nachfolgenden ersetzt
-; Monate ist ein Schlüssel und muss im Block vorhanden sein
+[monats_priv.ini]
+; hier können die Namen von zusätzlichen monatsabhängigen config.ini definiert werden.
 ; die Monate müssen immer zweistellig sein!!
-;Monate = 09, 10, 02
-;BatSparFaktor = 0.7
-;MaxLadung = 3000
-;MindBattLad = 35
-
-;[Winter]
-;Monate = 11, 12, 01
-;BatSparFaktor = 1.0
-;MaxLadung = 5000
-;MindBattLad = 50
+; Dateiname (immer kleinbuchstaben) = GülitgkeitsMonate
+;winter_priv.ini = 11, 12, 01
 
 [Reservierung]
 ; Hier kann die PV-Reserierung (z.B. für ein E-Auto nachmittags) eingeschaltet werden (1=ein, 0=aus)

--- a/CONFIG/winter.ini
+++ b/CONFIG/winter.ini
@@ -1,0 +1,4 @@
+[Ladeberechnung]
+BatSparFaktor = 1.0
+MaxLadung = 5000
+MindBattLad = 50

--- a/CONFIG/winter.ini
+++ b/CONFIG/winter.ini
@@ -2,3 +2,8 @@
 BatSparFaktor = 1.0
 MaxLadung = 5000
 MindBattLad = 50
+
+[EigenverbOptimum]
+GrundlastNacht = 500
+AkkuZielProz = 50
+MaxEinspeisung = 100

--- a/FUNCTIONS/functions.py
+++ b/FUNCTIONS/functions.py
@@ -37,7 +37,6 @@ class basics:
                 for (c_file, monate) in config.items('monats_priv.ini'):
                     if aktueller_Monat in monate:
                         c_file = 'CONFIG/'+c_file
-                        print(">>>>>>>>>>> Konfig von ", c_file)
                         try:
                             config.read_file(open(c_file))
                             config.read(c_file)

--- a/FUNCTIONS/functions.py
+++ b/FUNCTIONS/functions.py
@@ -10,11 +10,12 @@ class basics:
     def loadConfig(self, conf_files):
             # Damit die Variable config auch in der Funktion "getVarConf" vorhanden ist (global config)
             global config
+            # Damit kann man auch meherer configs nacheinander lesen
             try:
                 config
             except NameError:
                 config = configparser.ConfigParser()
-            # Damit kann man auch meherer configs nacheinander lesen
+            # Standard.ini lesen
             for conf_file in conf_files:
                 c_file = 'CONFIG/'+conf_file+'.ini'
                 try:
@@ -22,12 +23,23 @@ class basics:
                         config.read(c_file)
                 except:
                         print("\nERROR: ", e, "\n")
+            # _priv_ini lesen
             for conf_file in conf_files:
                 c_file = 'CONFIG/'+conf_file+'_priv.ini'
                 try:
                         config.read_file(open(c_file))
                         config.read(c_file)
                 except Exception as e:
+                        print("\nERROR: ", e, "\n")
+            # Monatsabhängige ini lesen
+            aktueller_Monat = str(datetime.strftime(datetime.now(), "%m"))
+            for (c_file, monate) in config.items('monats_priv.ini'):
+                if aktueller_Monat in monate:
+                    c_file = 'CONFIG/'+c_file
+                    try:
+                        config.read_file(open(c_file))
+                        config.read(c_file)
+                    except Exception as e:
                         print("\nERROR: ", e, "\n")
             return config
     
@@ -55,24 +67,6 @@ class basics:
         return()
     
     def getVarConf(self, var_block, var, Type):
-            aktueller_Monat = str(datetime.strftime(datetime.now(), "%m"))
-            # Für alle Varaiblen aus dem Block [Ladeberechnung] lesen welche Zusatz_Ladebloecke vorhanden sind
-            # ausgenommen die Variable Zusatz_Ladebloecke, wegen Endlosschleife
-            if (var_block == 'Ladeberechnung') and not (var_block == 'Ladeberechnung' and var == 'Zusatz_Ladebloecke'):
-                Bloecke = self.getVarConf('Ladeberechnung','Zusatz_Ladebloecke','str')
-                if ( Bloecke != 'aus' ):
-                    Bloecke = Bloecke.replace(" ", "")
-                    Bloecke = Bloecke.split(",")
-                    for Block in Bloecke:
-                        # Hier pruefen ob Monat in Ersatzblock vorkommt und dann Ersatzblockvariable lesen!!
-                        # Zusatz_configs lesen
-                        Ersatzmonate = self.getVarConf( Block ,'Monate','str')
-                        Ersatzmonate = Ersatzmonate.replace(" ", "")
-                        Ersatzmonate = Ersatzmonate.split(",")
-                        if ( aktueller_Monat in Ersatzmonate ):
-                            if ( var in config[ Block ] ):
-                                var_block = Block
-    
             # Variablen aus config lesen und auf Zahlen prüfen
             try:
                 if(Type == 'eval'):

--- a/FUNCTIONS/functions.py
+++ b/FUNCTIONS/functions.py
@@ -32,16 +32,18 @@ class basics:
                 except Exception as e:
                         print("\nERROR: ", e, "\n")
             # Monatsabhängige ini lesen
-            aktueller_Monat = str(datetime.strftime(datetime.now(), "%m"))
-            for (c_file, monate) in config.items('monats_priv.ini'):
-                if aktueller_Monat in monate:
-                    c_file = 'CONFIG/'+c_file
-                    try:
-                        config.read_file(open(c_file))
-                        config.read(c_file)
-                    except Exception as e:
-                        print("\nERROR: ", e, "\n")
-            return config
+            if ( 'charge' in conf_files ):
+                aktueller_Monat = str(datetime.strftime(datetime.now(), "%m"))
+                for (c_file, monate) in config.items('monats_priv.ini'):
+                    if aktueller_Monat in monate:
+                        c_file = 'CONFIG/'+c_file
+                        print(">>>>>>>>>>> Konfig von ", c_file)
+                        try:
+                            config.read_file(open(c_file))
+                            config.read(c_file)
+                        except Exception as e:
+                            print("\nERROR: ", e, "\n")
+                return config
     
     def loadWeatherData(self, weatherfile):
             data = None

--- a/README.md
+++ b/README.md
@@ -2,14 +2,15 @@
 ## ☀️ GEN24_Ladesteuerung 🔋 
 (getestet unter Python 3.8 und 3.9)  
 ![new](pics/new.png)  
+Ab Version: **0.24.4**  
+Auslagerung der jahreszeitenabhängingen Konfiguration in zusätzliche config-files.  
+Änderung in der CONFIG/charge.ini und charge_priv.ini, neuen Block [monats_priv.ini] eingefügt, usw.  
+Ab Version: **0.24.1**  
+Einbindung von Fronius-Symos.  
+Änderung in der CONFIG/default.ini `IP_weitere_Symo = no` in CONFIG/default_priv.ini einfügen.  
 Ab Version: **0.24.0**  
 Alle Daten aus den Steuerungs.json Dateien in SQLite-Datenbankdatei CONFIG/Prog_Steuerung.sqlite abgelegt.
 Änderungen in WebUI: Reiter Settings neu konzipiert, Schieberegler bei den Prozentangaben der Ladesteuerungen.  
-Ab Version: **0.22.0**  
-Die config.ini ins Verzeichnis CONFIG verschoben und aufgeteilt auf `default.ini, charge.ini weather.ini`.
-Zur jeweiligen `xy.ini` kann eine `xy_priv.ini` mit den persönlichen Anpassungen erstellt werden.  
-Ab Version: **0.21.4**  
-BattVollUm als Delta der ersten Prognosestunde, die kleiner als 1 % der maximalen PV-Leistung ist.  
 ![new](pics/new2.png)  
 
 - Prognosebasierte Ladesteuerung für  Fronius Symo GEN24 Plus um eine Einspeisebegrenzung (bei mir 70%) zu umgehen,
@@ -162,6 +163,11 @@ Weitere Erklärungen stehen in der verlinkten Hilfe oder im Wiki.
 ----------
 
 **News History:**  
+Ab Version: **0.22.0**  
+Die config.ini ins Verzeichnis CONFIG verschoben und aufgeteilt auf `default.ini, charge.ini weather.ini`.
+Zur jeweiligen `xy.ini` kann eine `xy_priv.ini` mit den persönlichen Anpassungen erstellt werden.  
+Ab Version: **0.21.4**  
+BattVollUm als Delta der ersten Prognosestunde, die kleiner als 1 % der maximalen PV-Leistung ist.  
 Ab Version: **0.21.3**  
 In der HTTP-Version kann nun im Energiemanagement, ein Einspeisezielwert der Eigenverbrauchs-Optimierung automatisch geschrieben werden.  
 Ab Version: **0.21.2**  

--- a/html/4_Hilfe.html
+++ b/html/4_Hilfe.html
@@ -197,31 +197,13 @@ td {font-size: 160%;
 <tr><td><input type="hidden" name="Zeile[46][0]" value=''>Akkuschonung</td>
 <td><input type="text" name="Zeile[46][1]" value="1" readonly></td></tr>
 <tr><td colspan="2"><input type="hidden" name="Zeile[47]" value='' ></td></tr>
-<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[48]" value='' >; hier müssen die Namen der zusätzlichen Konfigurationen definiert werden.</td></tr>
-<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[49]" value='' >; mit Zusatz_Ladebloecke = aus können die zusätzlichen Konfigurationen abgeschaltet werden</td></tr>
-<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[50]" value='' >; Zusatz_Ladebloecke = aus</td></tr>
-<tr><td><input type="hidden" name="Zeile[51][0]" value=''>Zusatz_Ladebloecke</td>
-<td><input type="text" name="Zeile[51][1]" value="Winter, Uebergang" readonly></td></tr>
-<tr><td colspan="2"><input type="hidden" name="Zeile[52]" value='' ></td></tr>
-<tr><th colspan="2"><input type="hidden" name="Zeile[53]" value='' >[Winter]</th></tr>
-<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[54]" value='' >; in den Wintermonaten werden die Standardwerte aus dem Block [Ladeberechnung] durch die Nachfolgenden ersetzt</td></tr>
-<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[55]" value='' >; Monate ist ein Schlüssel und muss im Block vorhanden sein</td></tr>
+<tr><th colspan="2"><input type="hidden" name="Zeile[53]" value='' >[monats_priv.ini]</th></tr>
+<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[54]" value='' >; hier können die Namen von zusätzlichen monatsabhängigen config.ini definiert werden.</td></tr>
 <tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[56]" value='' >; die Monate müssen immer zweistellig sein!!</td></tr>
-<tr><td><input type="hidden" name="Zeile[57][0]" value=''>Monate</td>
+<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[55]" value='' >; Dateiname (immer kleinbuchstaben) = GülitgkeitsMonate</td></tr>
+<tr><td><input type="hidden" name="Zeile[57][0]" value=''>winter_priv.ini</td>
 <td><input type="text" name="Zeile[57][1]" value="11, 12, 01" readonly></td></tr>
-<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[58]" value='' >; hier Werte für den Zusatz_Ladeblock angeben</td></tr>
-<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[59]" value='' >; die Liste ist nicht abschließend und kann erweitert werden</td></tr>
-<tr><td><input type="hidden" name="Zeile[60][0]" value=''>BatSparFaktor</td>
-<td><input type="text" name="Zeile[60][1]" value="1.5" readonly></td></tr>
-<tr><td><input type="hidden" name="Zeile[61][0]" value=''>MaxLadung</td>
-<td><input type="text" name="Zeile[61][1]" value="5000" readonly></td></tr>
-<tr><td><input type="hidden" name="Zeile[62][0]" value=''>WRSchreibGrenze_nachOben</td>
-<td><input type="text" name="Zeile[62][1]" value="700" readonly></td></tr>
-<tr><td><input type="hidden" name="Zeile[63][0]" value=''>WRSchreibGrenze_nachUnten</td>
-<td><input type="text" name="Zeile[63][1]" value="1600" readonly></td></tr>
-<tr><td><input type="hidden" name="Zeile[64][0]" value=''>MindBattLad</td>
-<td><input type="text" name="Zeile[64][1]" value="50" readonly></td></tr>
-<tr><td colspan="2"><input type="hidden" name="Zeile[65]" value='' ></td></tr>
+<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[58]" value='' >; Die werte für den Winter, müssen dann in der winter_priv.ini definiert werden.</td></tr>
 <tr><th colspan="2"><input type="hidden" name="Zeile[66]" value='' >[Uebergang]</th></tr>
 <tr><td><input type="hidden" name="Zeile[67][0]" value=''>Monate</td>
 <td><input type="text" name="Zeile[67][1]" value="09, 10, 02" readonly></td></tr>

--- a/html/4_tab_config_ini.php
+++ b/html/4_tab_config_ini.php
@@ -65,7 +65,7 @@ td {font-size: 160%;
 <body>
   <div class="hilfe"> <a href="4_Hilfe.html"><b>Hilfe</b></a></div>
 <div class="version" align="center">
-<b>  GEN24_Ladesteuerung Version: 0.24.3 </b>
+<b>  GEN24_Ladesteuerung Version: 0.24.4 </b>
 </div>
 <br>
 <?php


### PR DESCRIPTION
Auslagerung der jahreszeitenabhängigen Konfiguration in zusätzliche config-files  
Vorteil:
Man kann dort alle Definitionen, die in der charge.ini, bzw. charge_priv.ini enthalten sind, Monats abhängig ändern. Nicht nur aus dem Block [Ladeberechnung], sondern auch z.B. aus `[EigenverbOptimum] `usw.


#### ACHTUNG Änderung in der CONFIG/charge.ini und charge_priv.ini:  
- Definition der Zusatz_Ladebloecke und Zeilen mit Zusatz_Ladebloecke **entfernt**.
- Neuen Block [monats_priv.ini] eingefügt, hier zusätzliche config-files mit Monaten eintragen  
  Beispielconfig winter_priv.ini = 11, 12, 01 eingefügt und Protofile winter.ini eingefügt.

Aktivieren z.B. in CONFIG/charge_priv.ini  
- Kommentar entfernen und winter.ini nach winter_priv.ini umbenennen.
