### PR TITLE
Notstrom Reservekapazität (Entladebegrenzung)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Notstrom Reserverkapazität (Entladebegrenzung) höher setzen, wenn schlechte Prognose in nächsten 24 Stunden (HTTP-Version)
 
+- Netzdienliches Laden durch Prognosekappung, wenn BatSparFaktor = 0.  
 
 **[0.24.4] – 2024-09-08**  
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - WebUI automatischer reload alle 5 Minuten, und beim wechseln des Tab.  
   Logfile springt beim Öffnen ans Ende.
 
+- Notstrom Reserverkapazität (Entladebegrenzung) höher setzen, wenn schlechte Prognose in nächsten 24 Stunden (HTTP-Version)
+
+
 **[0.24.4] – 2024-09-08**  
 
 Auslagerung der jahreszeitenabhängingen Konfiguration in zusätzliche config-files  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-**[0.24.5] – 2024-XX-XX**  
+**[0.24.5] – 2024-09-22**  
 
 - WebUI automatischer reload alle 5 Minuten, und beim wechseln des Tab.  
   Logfile springt beim Öffnen ans Ende.

--- a/CONFIG/charge.ini
+++ b/CONFIG/charge.ini
@@ -7,8 +7,9 @@ FesteLadeleistung = -1
 ; Zahlen <= 0 wird Differenz zum Sonnenuntergang (= Prognosewert < 2% PV_Leistung_Watt)
 BattVollUm = -4
 
-; Faktor um Batteriekapazität für später aufzusparen.
-; Der aus der Prognose errechnete Batterieladewert wird mit dem BatSparFaktor multipliziert.
+; Faktor um mehr Batteriekapazität für später aufzusparen.
+; Wenn BatSparFaktor > 0: (Batteriekapazität) / (Zeit bis BatVollUm) * BatSparFaktor
+; Wenn BatSparFaktor == 0: Ladung an den Prognosespitzen (Netzdienlich)
 BatSparFaktor = 0.5
 
 ; Größter Batterieladewert, der im WR gesetzt werden soll, aber höchstens der maximale mögliche Ladewert!!!

--- a/FUNCTIONS/GEN24_API.py
+++ b/FUNCTIONS/GEN24_API.py
@@ -74,7 +74,6 @@ class gen24api:
                     url = requests.get(gen24url, timeout=2)
                     text = url.text
                     data = json.loads(text)
-                    #data = basics.loadWeatherData('WIGGFronius_Symo.json') 
                     API_Sym['aktuellePVProduktion'] += int(data['Body']['Data']['262144']['channels']['PowerReal_PAC_Sum'])
                     API_Sym['AC_Produktion'] +=  int(data['Body']['Data']['262144']['channels']['EnergyReal_WAC_Sum_EverSince'])
                     API_Sym['DC_Produktion'] += int(data['Body']['Data']['262144']['channels']['EnergyReal_WAC_Sum_EverSince'])
@@ -97,18 +96,11 @@ class gen24api:
                     #print(DB_DC, Offline_AC, API['DC_Produktion'], API['AC_Produktion'])
                     API['AC_Produktion'] = Offline_AC
                     API['DC_Produktion'] = DB_DC
-                    #print("AC_Produktion, DC_Produktion ", API['AC_Produktion'], API['DC_Produktion'])
-                    print("Symos OFF-Line ==>> AC_Produktion, DC_Produktion: ", API['AC_Produktion'], API['DC_Produktion'])  #WIGG
                     return(API)
 
-            print("Symos ON-Line ==>> AC_Produktion, DC_Produktion: ", API_Sym['AC_Produktion'], API_Sym['DC_Produktion'])  #WIGG
-            print("GEN24 ==>> AC_Produktion, DC_Produktion: ", API['AC_Produktion'], API['DC_Produktion'])  #WIGG
-            #print(API['AC_Produktion'], API_Sym['AC_Produktion'])
-            #print(API['DC_Produktion'], API_Sym['DC_Produktion'])
             API['aktuellePVProduktion'] += API_Sym['aktuellePVProduktion']
             API['AC_Produktion'] += API_Sym['AC_Produktion']
             API['DC_Produktion'] += API_Sym['DC_Produktion']
-            #print(API['AC_Produktion'], API['DC_Produktion'])
 
 
         return(API)

--- a/FUNCTIONS/PrognoseLadewert.py
+++ b/FUNCTIONS/PrognoseLadewert.py
@@ -300,8 +300,10 @@ class progladewert:
         PrognoseMorgen_arr = self.getPrognoseMorgen(MaxEinspeisung)
         PrognoseMorgen = PrognoseMorgen_arr[0]/1000
         Ende_Nacht_Std = PrognoseMorgen_arr[1]
-        Eigen_Opt_Std_arry = request.get_eigenv_opt(host_ip, user, password)
+        Eigen_Opt_Std_arry = request.get_batteries(host_ip, user, password)
         Eigen_Opt_Std = Eigen_Opt_Std_arry[0]
+        Eigen_Opt_auto = Eigen_Opt_Std_arry[1]
+        Backup_Reserve = Eigen_Opt_Std_arry[2]
     
         if Ende_Nacht_Std == 0 : Ende_Nacht_Std = datetime.strftime(self.now, "%Y-%m-%d %H:%M:%S")
         Dauer_Nacht = (datetime.strptime(Ende_Nacht_Std, '%Y-%m-%d %H:%M:%S') - (self.now  - timedelta(hours=1)))
@@ -351,11 +353,11 @@ class progladewert:
                 DEBUG_Eig_opt += "\nDEBUG ## >>> EigenverbOpt_steuern == 2, keine Einspeisung während des Tages"
 
     
-        # Wenn Eigen_Opt_Std_arry[1] = 0, Eigenverbrauchs-Optimierung = Automatisch = 0
-        if Eigen_Opt_Std_arry[1] == 0: Eigen_Opt_Std = 0
+        # Wenn  Eigen_Opt_auto = 0, Eigenverbrauchs-Optimierung = Automatisch = 0
+        if Eigen_Opt_auto == 0: Eigen_Opt_Std = 0
     
         # Einspeisung muss immer Minus sein!!
         Eigen_Opt_Std_neu = abs(Eigen_Opt_Std_neu) * -1
     
-        return PrognoseMorgen, Eigen_Opt_Std, int(Eigen_Opt_Std_neu), Dauer_Nacht_Std, AkkuZielProz, DEBUG_Eig_opt
+        return PrognoseMorgen, Eigen_Opt_Std, int(Eigen_Opt_Std_neu), Dauer_Nacht_Std, AkkuZielProz, DEBUG_Eig_opt, Backup_Reserve
     

--- a/FUNCTIONS/Steuerdaten.py
+++ b/FUNCTIONS/Steuerdaten.py
@@ -40,7 +40,7 @@ class readcontroldata:
             if Parameter == 'logging':
                 Options = ['logging']
             if Parameter == 'schreiben':
-                Options = ['logging','laden','entladen','optimierung']
+                Options = ['logging','laden','entladen','optimierung','notstrom']
         # Ab hier WebUI-Settings
         if Prog_Steuer_code == 1:
             Meldung = "AUS (WR löschen)"

--- a/FUNCTIONS/httprequest.py
+++ b/FUNCTIONS/httprequest.py
@@ -55,7 +55,7 @@ class request:
         result = json.loads(response.text)['timeofuse']
         return result
     
-    def get_eigenv_opt(self, g_self_address, g_user, g_password):
+    def get_batteries(self, g_self_address, g_user, g_password):
         global user, password, self_address
         user = g_user.lower()
         password = g_password
@@ -67,8 +67,8 @@ class request:
         HYB_EM_POWER = json.loads(response.text)['HYB_EM_POWER']
         # wenn HYB_EM_MODE = 0, Eigenverbrauchs-Optimierung = Automatisch
         HYB_EM_MODE = json.loads(response.text)['HYB_EM_MODE']
-        return HYB_EM_POWER, HYB_EM_MODE
-    
+        HYB_BACKUP_RESERVED = json.loads(response.text)['HYB_BACKUP_RESERVED']
+        return HYB_EM_POWER, HYB_EM_MODE, HYB_BACKUP_RESERVED
     
     def send_request(self, path, method='GET',payload="", params=None, headers={}, auth=False):
         global DEBUG_Ausgabe_fun_http
@@ -93,19 +93,10 @@ class request:
                 response = requests.request(method=method, url=url, params=params, headers=headers,data=payload)
         
                 if response.status_code == 200:
-                    # DEBUG print("SPO## response: ",response)
-                    # method='POST'
-                    # Energiemanagement ->  Batteriemanagement  -> Max. Entladeleistung (="DISCHARGE_MAX")
-                    #path = '/config/timeofuse'
-                    #payload = '{"timeofuse":[{"Active":true,"Power":1,"ScheduleType":"DISCHARGE_MAX","TimeTable":{"Start":"00:00","End":"23:59"},"Weekdays":{"Mon":true,"Tue":true,"Wed":true,"Thu":true,"Fri":true,"Sat":true,"Sun":true}}]}'
-                    # Energiemanagement -> Eigenverbrauchs-Optimierung -> Manuell = "HYB_EM_MODE":1
-                    #path = '/config/batteries'
-                    #payload = '{"HYB_EM_POWER":-124,"HYB_EM_MODE":1}'
                     return response
                 elif response.status_code == 401: #unauthorized
                     nonce = self.get_nonce(response)
                     if i > 1:
-                        # DEBUG print('[Fronius] Login failed 3 times .. aborting')
                         print('[Fronius] Login fehlgeschlagen .. falsche Zugangsdaten?')
                         exit()
                     if (response.status_code==200):

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 ## ☀️ GEN24_Ladesteuerung 🔋 
 (getestet unter Python 3.8 und 3.9)  
 ![new](pics/new.png)  
+Ab Version: **0.24.5**  
+Notstrom Reserverkapazität (Entladebegrenzung) höher setzen, wenn schlechte Prognose morgen.   
 Ab Version: **0.24.4**  
 Auslagerung der jahreszeitenabhängingen Konfiguration in zusätzliche config-files.  
 Änderung in der CONFIG/charge.ini und charge_priv.ini, neuen Block [monats_priv.ini] eingefügt, usw.  

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ![new](pics/new.png)  
 Ab Version: **0.24.5**  
 Notstrom Reserverkapazität (Entladebegrenzung) höher setzen, wenn schlechte Prognose morgen.   
+Netzdienliches Laden durch Prognosekappung, wenn BatSparFaktor = 0.  
 Ab Version: **0.24.4**  
 Auslagerung der jahreszeitenabhängingen Konfiguration in zusätzliche config-files.  
 Änderung in der CONFIG/charge.ini und charge_priv.ini, neuen Block [monats_priv.ini] eingefügt, usw.  
@@ -20,7 +21,7 @@ und eine Produktion über der AC-Ausgangsleistungsgrenze des WR als DC in die Ba
 Über die Tabelle [Ladesteuerung](https://github.com/wiggal/GEN24_Ladesteuerung/#batterieladesteuerung--tab---ladesteuerung-) können große, geplante Verbräuche bei der Ladeplanung berücksichtigt werden.  
 - [Entladesteuerung,](https://github.com/wiggal/GEN24_Ladesteuerung/#batterieentladesteuerung--tab---entladesteuerung-) um die Entladung der Batterie bei großen Verbräuchen zu steuern.  
 - [Logging](https://github.com/wiggal/GEN24_Ladesteuerung/#bar_chart-logging) und grafische Darstellung von Produktion und Verbrauch.  
-- Akkuschonung: Um eine LFP-Akku zu schonen, wird die Ladeleistung ab 80% auf 0,2C und ab 90% auf 0,1C beschränkt.  
+- Akkuschonung: Um einen LFP-Akku zu schonen, wird die Ladeleistung ab 80% auf 0,2C und ab 90% auf 0,1C beschränkt.  
 
 Die Ladung des Hausakkus erfolgt prognosebasiert und kann mit der Variablen „BatSparFaktor“ in der „config.ini“ gesteuert werden.  
 Hier eine Grafik um die Auswirkung des „BatSparFaktor“ zu verdeutlichen:  

--- a/SymoGen24Controller2.py
+++ b/SymoGen24Controller2.py
@@ -457,7 +457,7 @@ if __name__ == '__main__':
                         ProgGrenzeMorgen = basics.getVarConf('Entladung','ProgGrenzeMorgen','eval')
                         EntladeGrenze_Min = basics.getVarConf('Entladung','EntladeGrenze_Min','eval')
                         EntladeGrenze_Max = basics.getVarConf('Entladung','EntladeGrenze_Max','eval')
-                        PrognoseMorgen = getPrognoseMorgen()[0]/1000
+                        PrognoseMorgen = progladewert.getPrognoseMorgen()[0]/1000
                         Battery_MinRsvPct = int(gen24.read_data('Battery_MinRsvPct')/100)
                         Neu_Battery_MinRsvPct = EntladeGrenze_Min
                         if (PrognoseMorgen < ProgGrenzeMorgen and PrognoseMorgen != 0):

--- a/SymoGen24Controller2.py
+++ b/SymoGen24Controller2.py
@@ -136,7 +136,8 @@ if __name__ == '__main__':
                     alterLadewert = int(oldPercent*BattganzeLadeKapazWatt/10000)
     
                     format_aktStd = "%Y-%m-%d %H:00:00"
-    
+                    aktStd = datetime.strftime(now, "%H:00")
+
     
                     #######################################
                     ## Ab hier geht die Berechnung los
@@ -288,7 +289,8 @@ if __name__ == '__main__':
                     if aktuellePVProduktion < 10:
                         # Für die Nacht zwingend auf MaxLadung, 
                         # da sonst mogends evtl nicht auf 0 gestelltwerden kann, wegen WRSchreibGrenze_nachUnten
-                        if alterLadewert < MaxLadung -10 :
+                        Akt_Std = int(datetime.strftime(now, "%H"))
+                        if alterLadewert < MaxLadung -10 and Akt_Std > 12:
                             aktuellerLadewert = MaxLadung
                             DATA = progladewert.setLadewert(aktuellerLadewert, WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten, BattganzeLadeKapazWatt, alterLadewert)
                             newPercent = DATA[0]
@@ -381,8 +383,6 @@ if __name__ == '__main__':
                         if (entladesteurungsdata.get('ManuelleEntladesteuerung')):
                             MaxEntladung = int(entladesteurungsdata['ManuelleEntladesteuerung']['Res_Feld1'])
                             DEBUG_Ausgabe+="\nDEBUG MaxEntladung = entladesteurungsdata:" + str(MaxEntladung)
-
-                        aktStd = datetime.strftime(now, "%H:00")
 
                         # Verbrauchsgrenze Entladung lesen
                         if (entladesteurungsdata.get(aktStd)):

--- a/html/4_Hilfe.html
+++ b/html/4_Hilfe.html
@@ -142,8 +142,9 @@ td {font-size: 160%;
 <tr><td><input type="hidden" name="Zeile[10][0]" value=''>BattVollUm</td>
 <td><input type="text" name="Zeile[10][1]" value="-4" readonly></td></tr>
 <tr><td colspan="2"><input type="hidden" name="Zeile[11]" value='' ></td></tr>
-<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[12]" value='' >; Faktor um Batteriekapazität für später aufzusparen.</td></tr>
-<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[13]" value='' >; Der aus der Prognose errechnete Batterieladewert wird mit dem BatSparFaktor multipliziert.</td></tr>
+<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[12]" value='' >; Faktor um mehr Batteriekapazität für später aufzusparen.<br>
+; Wenn BatSparFaktor > 0: Berechnung nach [ (Batteriekapazität) / (Zeit bis BatVollUm) * BatSparFaktor ]<br>
+; Wenn BatSparFaktor == 0: Ladung an den Prognosespitzen (Netzdienlich).</td></tr>
 <tr><td><input type="hidden" name="Zeile[14][0]" value=''>BatSparFaktor</td>
 <td><input type="text" name="Zeile[14][1]" value="0.5" readonly></td></tr>
 <tr><td colspan="2"><input type="hidden" name="Zeile[15]" value='' ></td></tr>

--- a/html/4_Hilfe.html
+++ b/html/4_Hilfe.html
@@ -226,13 +226,15 @@ td {font-size: 160%;
 <tr><td><input type="hidden" name="Zeile[85][0]" value=''>WREntladeSchreibGrenze_Watt</td>
 <td><input type="text" name="Zeile[85][1]" value="200" readonly></td></tr>
 <tr><td colspan="2"><input type="hidden" name="Zeile[86]" value='' ></td></tr>
-<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[79]" value='' >; Nur MODBUS</td></tr>
+<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[79]" value='' >; HTTP und MODBUS</td></tr>
 <tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[87]" value='' >; Entladung des Akku auf bestimmten Prozentsatz begrenzen (1=ein, 0=aus)</td></tr>
+<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[87]" value='' >; In der HTTP-Version: Einstellen der Notstrom Reservekapazität</td></tr>
 <tr><td><input type="hidden" name="Zeile[88][0]" value=''>EntladeGrenze_steuern</td><td><input type="text" name="Zeile[88][1]" value="0" readonly></td></tr>
 <tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[89]" value='' >; PrognoseGrenzeMorgen in KWh</td></tr>
 <tr><td><input type="hidden" name="Zeile[90][0]" value=''>ProgGrenzeMorgen</td>
 <td><input type="text" name="Zeile[90][1]" value="10" readonly></td></tr>
 <tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[91]" value='' >; Entladegrenzen in %</td></tr>
+<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[91]" value='' >; In der HTTP-Version wird EntladeGrenze_Min automatisch auf 5% begrenzt, wenn der Wert kleiner ist.</td></tr>
 <tr><td><input type="hidden" name="Zeile[92][0]" value=''>EntladeGrenze_Min</td>
 <td><input type="text" name="Zeile[92][1]" value="0" readonly></td></tr>
 <tr><td><input type="hidden" name="Zeile[93][0]" value=''>EntladeGrenze_Max</td>

--- a/html/9_Hilfe.html
+++ b/html/9_Hilfe.html
@@ -51,6 +51,8 @@
 <td><b>Entladesteuerung</b></td><td>Die Entladesteuerung wird oberhalb der Schreibgrenzen geschrieben.</td> </tr>
 <tr> <td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
 <td><b>Eigenverbrauchs-Optimierung</b></td><td>Die Eigenverbrauchs-Optimierung wird oberhalb der Schreibgrenzen geschrieben.</td> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+<td><b>Notstromreserve</b></td><td>Die Notstrom Reservekapazität wird oberhalb der Schreibgrenzen geschrieben.</td> </tr>
 </table>
 
 <br/><br/>

--- a/html/9_tab_settigs.php
+++ b/html/9_tab_settigs.php
@@ -93,7 +93,6 @@ input[type="checkbox"] {
  <body onload="disablecheckboxes()">
  <div class="hilfe" align="right"> <a href="9_Hilfe.html"><b>Hilfe</b></a></div>
   <div class="container">
-   <br />
    <div class="hilfe" align="center"><p>
    <b>ACHTUNG:</b> Wenn die WebUI-Settings nicht ausgeschaltet sind, 
    <br>überschreiben sie die Aufrufparameter des Skriptes (z.B. vom Cronjob)!
@@ -118,7 +117,7 @@ for ($i = 0; $i <= 4; $i++) {
 
 #Checkbox wie in DB setzen
 $CheckOptionsDB = explode(":", $EV_Reservierung['23:09']['Options']);
-$CheckOptionsALL = array("logging", "laden", "entladen", "optimierung");
+$CheckOptionsALL = array("logging", "laden", "entladen", "optimierung",'notstrom');
 $Setting_check = array();
 foreach ($CheckOptionsALL as &$option) {
     if (in_array($option, $CheckOptionsDB)) {
@@ -142,6 +141,7 @@ foreach ($CheckOptionsALL as &$option) {
  <label style="padding: 5px 50px" class="auswahllabel" ><input type="checkbox" name="hausakkuladung.option" id="steuer6" value="laden" <?php echo $Setting_check['laden'] ?> >Ladesteuerung</label>
  <label style="padding: 5px 50px" class="auswahllabel" ><input type="checkbox" name="hausakkuladung.option" id="steuer7" value="entladen" <?php echo $Setting_check['entladen'] ?> >Entladesteuerung</label>
  <label style="padding: 5px 50px" class="auswahllabel" ><input type="checkbox" name="hausakkuladung.option" id="steuer8" value="optimierung" <?php echo $Setting_check['optimierung'] ?> >Eigenverbrauchs-Optimierung</label>
+ <label style="padding: 5px 50px" class="auswahllabel" ><input type="checkbox" name="hausakkuladung.option" id="steuer9" value="notstrom" <?php echo $Setting_check['notstrom'] ?> >Notstromreserve</label>
 </div>
 </div>
 
@@ -157,6 +157,7 @@ function disablecheckboxes() {
     document.getElementById("steuer6").disabled = false;
     document.getElementById("steuer7").disabled = false;
     document.getElementById("steuer8").disabled = false;
+    document.getElementById("steuer9").disabled = false;
   } else {
     document.getElementById("steuer5").checked = false;
     document.getElementById("steuer5").disabled = true;
@@ -166,6 +167,8 @@ function disablecheckboxes() {
     document.getElementById("steuer7").disabled = true;
     document.getElementById("steuer8").checked = false;
     document.getElementById("steuer8").disabled = true;
+    document.getElementById("steuer9").checked = false;
+    document.getElementById("steuer9").disabled = true;
   }
 }
 </script>

--- a/http_SymoGen24Controller2.py
+++ b/http_SymoGen24Controller2.py
@@ -139,7 +139,7 @@ if __name__ == '__main__':
                     WR_schreiben = 0
     
                     format_aktStd = "%Y-%m-%d %H:00:00"
-    
+                    aktStd = datetime.strftime(now, "%H:00")
     
                     #######################################
                     ## Ab hier geht die Berechnung los
@@ -275,7 +275,8 @@ if __name__ == '__main__':
                     if aktuellePVProduktion < 10:
                         # Für die Nacht zwingend auf MaxLadung, 
                         # da sonst mogends evtl nicht auf 0 gestelltwerden kann, wegen WRSchreibGrenze_nachUnten
-                        if alterLadewert < MaxLadung -10 :
+                        Akt_Std = int(datetime.strftime(now, "%H"))
+                        if alterLadewert < MaxLadung -10 and Akt_Std > 12:
                             aktuellerLadewert = MaxLadung
                             DATA = progladewert.setLadewert(aktuellerLadewert, WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten, BattganzeLadeKapazWatt, alterLadewert)
                             WR_schreiben = DATA[1]
@@ -338,8 +339,6 @@ if __name__ == '__main__':
                         if (entladesteurungsdata.get('ManuelleEntladesteuerung')):
                             MaxEntladung = int(entladesteurungsdata['ManuelleEntladesteuerung']['Res_Feld1']*BattganzeLadeKapazWatt / 100)
                             DEBUG_Ausgabe+="\nDEBUG MaxEntladung = entladesteurungsdata:" + str(MaxEntladung)
-
-                        aktStd = datetime.strftime(now, "%H:00")
 
                         # Verbrauchsgrenze Entladung lesen
                         if (entladesteurungsdata.get(aktStd)):

--- a/http_SymoGen24Controller2.py
+++ b/http_SymoGen24Controller2.py
@@ -377,7 +377,7 @@ if __name__ == '__main__':
 
                         ## Werte zum Überprüfen ausgeben
                         if print_level >= 1:
-                            print("######### E N T L A D E S T E U E R U N G #########\n")
+                            print("## ENTLADESTEUERUNG ##\n")
                             print("Feste Entladegrenze:       ", int(entladesteurungsdata['ManuelleEntladesteuerung']['Res_Feld1']*BattganzeLadeKapazWatt / 100), "W")
                             print("Batteriestatus in Prozent: ", BattStatusProz, "%")
                             print("GesamtverbrauchHaus:       ", GesamtverbrauchHaus, "W")
@@ -455,7 +455,7 @@ if __name__ == '__main__':
 
                         if (Dauer_Nacht_Std > 1 or BattStatusProz < AkkuZielProz) and aktuellePVProduktion_tmp < (Grundlast + MaxEinspeisung) * 1.5:
                             if print_level >= 1:
-                                print("### Eigenverbrauchs-Optimierung ###")
+                                print("## Eigenverbrauchs-Optimierung ##")
                                 print("Prognose Morgen: ", PrognoseMorgen, "KW")
                                 print("Eigenverbrauchs-Opt. ALT: ", Eigen_Opt_Std, "W")
                                 print("Eigenverbrauchs-Opt. NEU: ", Eigen_Opt_Std_neu, "W")
@@ -496,7 +496,7 @@ if __name__ == '__main__':
                         if (PrognoseMorgen < ProgGrenzeMorgen and PrognoseMorgen != 0):
                             Neu_HYB_BACKUP_RESERVED = EntladeGrenze_Max
                         if print_level >= 1:
-                            print("######### N O T S T R O M R E S E R V E #########\n")
+                            print("## NOTSTROMRESERVE ##")
                             print("Prognose Morgen:     ", int(PrognoseMorgen), "KW")
                             print("ProgGrenze Morgen:   ", ProgGrenzeMorgen, "KW")
                             print("Batteriereserve:     ", HYB_BACKUP_RESERVED, "%")
@@ -509,13 +509,13 @@ if __name__ == '__main__':
                             if ('notstrom' in Options):
                                 response = request.send_request('/config/batteries', method='POST', payload ='{"HYB_BACKUP_CRITICALSOC":5,"HYB_BACKUP_RESERVED":'+ str(Neu_HYB_BACKUP_RESERVED) + '}')
                                 bereits_geschrieben = 1
-                                DEBUG_Ausgabe+="\nDEBUG Meldung Entladegrenze schreiben: " + str(response)
-                                Schreib_Ausgabe = Schreib_Ausgabe + "Folgender Wert wurde geschrieben für Batterieentladebegrenzung: " + str(Neu_HYB_BACKUP_RESERVED) + "%\n"
+                                DEBUG_Ausgabe+="\nDEBUG Meldung Notstromreserve schreiben: " + str(response)
+                                Schreib_Ausgabe = Schreib_Ausgabe + str(Neu_HYB_BACKUP_RESERVED) + "% Notstromreserve geschrieben.\n"
                                 Push_Schreib_Ausgabe = Push_Schreib_Ausgabe + Schreib_Ausgabe 
                             else:
-                                Schreib_Ausgabe = Schreib_Ausgabe + "Batterieentladebegrenzung NICHT geschrieben, da Option \"notstrom\" NICHT gesetzt!\n"
+                                Schreib_Ausgabe = Schreib_Ausgabe + "Notstromreserve NICHT geschrieben, da Option \"notstrom\" NICHT gesetzt!\n"
                         else:
-                            Schreib_Ausgabe = Schreib_Ausgabe + "Batterieentladebegrenzung hat sich nicht verändert, NICHTS zu schreiben!!\n"
+                            Schreib_Ausgabe = Schreib_Ausgabe + "Notstromreserve, NICHTS zu schreiben!!\n"
 
                         if print_level >= 1:
                             print(Schreib_Ausgabe)

--- a/http_SymoGen24Controller2.py
+++ b/http_SymoGen24Controller2.py
@@ -140,6 +140,7 @@ if __name__ == '__main__':
     
                     format_aktStd = "%Y-%m-%d %H:00:00"
                     aktStd = datetime.strftime(now, "%H:00")
+                    Akt_Std = int(datetime.strftime(now, "%H"))
     
                     #######################################
                     ## Ab hier geht die Berechnung los
@@ -275,7 +276,6 @@ if __name__ == '__main__':
                     if aktuellePVProduktion < 10:
                         # Für die Nacht zwingend auf MaxLadung, 
                         # da sonst mogends evtl nicht auf 0 gestelltwerden kann, wegen WRSchreibGrenze_nachUnten
-                        Akt_Std = int(datetime.strftime(now, "%H"))
                         if alterLadewert < MaxLadung -10 and Akt_Std > 12:
                             aktuellerLadewert = MaxLadung
                             DATA = progladewert.setLadewert(aktuellerLadewert, WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten, BattganzeLadeKapazWatt, alterLadewert)
@@ -480,7 +480,7 @@ if __name__ == '__main__':
                     ######## Eigenverbrauchs-Optimierung  ENDE!!!
 
                     ######## N O T S T R O M R E S E R V E ab hier setzen, wenn eingeschaltet!
-                    if  EntladeGrenze_steuern == 1 and aktuellePVProduktion < 8210: #WIGG
+                    if  EntladeGrenze_steuern == 1 and Akt_Std > 20 and aktuellePVProduktion < 10:
                         DEBUG_Ausgabe+="\nDEBUG <<<<<<<< Notstromreserve >>>>>>>>>>>>>"
 
                         ProgGrenzeMorgen = basics.getVarConf('Entladung','ProgGrenzeMorgen','eval')


### PR DESCRIPTION
Notstrom Reservekapazität (Entladebegrenzung) höher setzen, wenn schlechte Prognose in nächsten 24 Stunden (HTTP-Version wie in Modbus-Version)