### PR TITLE
Akkuschonung frei konfigurierbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-**[0.24.8] – 2024-10-XX**  
+**[0.24.8] – 2024-10-13**  
 
 - Akkuschonung frei konfigurierbar machen:  
 Änderung in CONFIG/charge.ini, folgede Zeilen eingefügt:  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**[0.24.8] – 2024-10-XX**  
+
+- Akkuschonung frei konfigurierbar machen
+
 **[0.24.7] – 2024-10-06**  
 
 Notstromprüfung nur zwischen 22:00 und 24:00 Uhr.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 Änderung in CONFIG/charge.ini, folgede Zeilen eingefügt:  
 ```
 ; Akkuschonung_Werte = {"Ladestand%" : "LadewertC", ...}
-Akkuschonung_Werte = {"90": "0.1", "80": "0.2", "95": "0.05"}
+Akkuschonung_Werte = {"80": "0.2", "90": "0.1", "95": "0.05"}
 ```
 Bitte in CONFIG/charge.ini übernehmen und anpassen. Es können auch mehr Akkuladepunkte eingefügt werden.
+
+- Fix: Eigenverbrauchs-Optimierung konnte unter tags nicht unter 50 Watt sein.
 
 **[0.24.7] – 2024-10-06**  
 
@@ -16,7 +18,7 @@ Wetterdienste FIX: json.decoder.JSONDecodeError wenn keine Daten ankommen
 **[0.24.6] – 2024-09-29**  
 
 - FIX: Schreibverzögerung bei Eigenverbrauchs-Optimierung funktioniert nicht bei MaxEinspeisung < 100W   
-- Fix: Prognoseholen mit WeatherDataProvider2.py von forecast.solar funktionierte nicht mehr.  
+- Fix: Prognose holen mit WeatherDataProvider2.py von forecast.solar funktionierte nicht mehr.  
 
 **[0.24.5] – 2024-09-22**  
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 **[0.24.8] – 2024-10-XX**  
 
-- Akkuschonung frei konfigurierbar machen
+- Akkuschonung frei konfigurierbar machen:  
+Änderung in CONFIG/charge.ini, folgede Zeilen eingefügt:  
+```
+; Akkuschonung_Werte = {"Ladestand%" : "LadewertC", ...}
+Akkuschonung_Werte = {"90": "0.1", "80": "0.2", "95": "0.05"}
+```
+Bitte in CONFIG/charge.ini übernehmen und anpassen. Es können auch mehr Akkuladepunkte eingefügt werden.
 
 **[0.24.7] – 2024-10-06**  
 

--- a/CONFIG/charge.ini
+++ b/CONFIG/charge.ini
@@ -44,6 +44,8 @@ GrenzwertGroestePrognose = 2000
 ; und BattVollUm wird um eine Stunde vor verlegt, da am Schluss nicht mehr so stark geladen wird.
 ; ACHTUNG: Eine Überschreitung der Einspeisegrenze bzw. AC-Leistung des WR setzt die Akkuschonung aus!
 Akkuschonung = 1
+; Akkuschonung_Werte = {"Ladestand%" : "LadewertC", ...}
+Akkuschonung_Werte = {"90": "0.1", "80": "0.2", "95": "0.05"}
 
 [monats_priv.ini]
 ; hier können die Namen von zusätzlichen monatsabhängigen config.ini definiert werden.

--- a/CONFIG/charge.ini
+++ b/CONFIG/charge.ini
@@ -39,13 +39,12 @@ LadungAus = 0
 ; Wenn größter Prognosewert je Stunde ist kleiner als GrenzwertGroestePrognose volle Ladung (= MaxLadung)
 GrenzwertGroestePrognose = 2000
 
-; Akkuschonung (0=aus, 0.1 bis 1.0 ein) dadurch wird der Akku zwischen 80 und 95% mit 0,2C bzw. 0,1C geladen
-; Ab 95% wir mit 0,1C mal Akkuschonung (z.B.: 0.1x0.5 = 0.05C) geladen
-; und BattVollUm wird um eine Stunde vor verlegt, da am Schluss nicht mehr so stark geladen wird.
+; Akkuschonung (0=aus, 1=ein) 
+; Wenn Akkuschonung ein, wird BattVollUm um eine Stunde vor verlegt, da am Schluss nicht mehr so stark geladen wird.
 ; ACHTUNG: Eine Überschreitung der Einspeisegrenze bzw. AC-Leistung des WR setzt die Akkuschonung aus!
 Akkuschonung = 1
 ; Akkuschonung_Werte = {"Ladestand%" : "LadewertC", ...}
-Akkuschonung_Werte = {"90": "0.1", "80": "0.2", "95": "0.05"}
+Akkuschonung_Werte = {"80": "0.2", "90": "0.1", "95": "0.05"}
 
 [monats_priv.ini]
 ; hier können die Namen von zusätzlichen monatsabhängigen config.ini definiert werden.

--- a/FUNCTIONS/PrognoseLadewert.py
+++ b/FUNCTIONS/PrognoseLadewert.py
@@ -344,9 +344,11 @@ class progladewert:
                     DEBUG_Eig_opt += "\nDEBUG ## >>> PrognoseMorgen: " + str(PrognoseMorgen) + ", PrognoseGrenzeMorgen: " + str(PrognoseGrenzeMorgen) 
                     Eigen_Opt_Std_neu = 0
                 else:
-                    Eigen_Opt_Std_neu = 50
+                    Grenze = 50
+                    if MaxEinspeisung < 50: Grenze = MaxEinspeisung
+                    Eigen_Opt_Std_neu = Grenze
                     DEBUG_Eig_opt += "DEBUG ## >>> BattStatusProz: " + str(BattStatusProz) + ", ist kleiner als AkkuZielProz: " + str(AkkuZielProz) 
-                    DEBUG_Eig_opt += "\nDEBUG ## >>> 50 Watt während des Tages"
+                    DEBUG_Eig_opt += "\nDEBUG ## >>>  " + str(Eigen_Opt_Std_neu) + " Watt während des Tages"
 
             # Wenn EigenverbOpt_steuern 2 Optimierung ueber Tags = 0
             if (EigenverbOpt_steuern == 2):

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 ## ☀️ GEN24_Ladesteuerung 🔋 
 (getestet unter Python 3.8 und 3.9)  
 ![new](pics/new.png)  
+Ab Version: **0.24.8**  
+Werte für Akkuschonung frei konfigurierbar.  
 Ab Version: **0.24.5**  
 Notstrom Reserverkapazität (Entladebegrenzung) höher setzen, wenn schlechte Prognose morgen.   
 Netzdienliches Laden durch Prognosekappung, wenn BatSparFaktor = 0.  

--- a/SymoGen24Controller2.py
+++ b/SymoGen24Controller2.py
@@ -246,35 +246,15 @@ if __name__ == '__main__':
                     # Wenn Akkuschonung > 0 ab 80% Batterieladung mit Ladewert runter fahren
                     HysteProdFakt = 2
                     if Akkuschonung > 0:
-                        Ladefaktor = 1
-                        BattStatusProz_Grenze = 100
-                        # Schaltverzoegerung neu 
-                        if (BattStatusProz >= 78 and ( abs((BattganzeLadeKapazWatt * 0.2) - alterLadewert) < 3 )) or BattStatusProz >= 80:
-                            Ladefaktor = 0.2
-                            AkkuSchonGrund = '80%, Ladewert = 0.2C'
-                            BattStatusProz_Grenze = 80
-                        if (BattStatusProz >= 88 and ( abs((BattganzeLadeKapazWatt * 0.1) - alterLadewert) < 3 )) or BattStatusProz >= 90:
-                            Ladefaktor = 0.1
-                            AkkuSchonGrund = '90%, Ladewert = 0.1C'
-                            BattStatusProz_Grenze = 90
-                        if (BattStatusProz >= 94 and ( abs((BattganzeLadeKapazWatt * 0.1* Akkuschonung) - alterLadewert) < 3 )) or BattStatusProz >= 95:
-                            Ladefaktor = 0.1 * Akkuschonung
-                            AkkuSchonGrund = '95%, Ladewert = ' + str(Ladefaktor) + 'C'
-                            BattStatusProz_Grenze = 95
-
-                        AkkuschonungLadewert = int(BattganzeLadeKapazWatt * Ladefaktor)
-                        # Bei Akkuschonung Schaltverzögerung (hysterese), wenn Ladewert ist bereits der Akkuschonwert (+/- 3W) BattStatusProz_Grenze 5% runter
-                        if ( abs(AkkuschonungLadewert - alterLadewert) < 3 ):
-                            BattStatusProz_Grenze = BattStatusProz_Grenze * 0.95
-                            HysteProdFakt = 5
+                        Akkuschonung_dict = progladewert.getAkkuschonWert(BattStatusProz, BattganzeLadeKapazWatt, alterLadewert, aktuellerLadewert)
+                        AkkuschonungLadewert = Akkuschonung_dict[0]
+                        HysteProdFakt = Akkuschonung_dict[1]
+                        BattStatusProz_Grenze = Akkuschonung_dict[2]
+                        AkkuSchonGrund = Akkuschonung_dict[3]
+                        DEBUG_Ausgabe += Akkuschonung_dict[4]
 
                         if BattStatusProz >= BattStatusProz_Grenze:
-                            DEBUG_Ausgabe += "\nDEBUG <<<<<< Meldungen von Akkuschonung >>>>>>> "
-                            DEBUG_Ausgabe += "\nDEBUG AkkuschonungLadewert-alterLadewert: " + str(abs(AkkuschonungLadewert - alterLadewert))
-                            DEBUG_Ausgabe += "\nDEBUG BattStatusProz_Grenze: " + str(BattStatusProz_Grenze)
-                            DEBUG_Ausgabe += "\nDEBUG AkkuschonungLadewert: " + str(AkkuschonungLadewert) + "\n"
-                            DEBUG_Ausgabe += "DEBUG aktuellerLadewert: " + str(aktuellerLadewert) + "\n"
-                            # Um das setzen der Akkuschonung zu verhindern, wenn zu wenig PV Energie kommt oder der Akku wieder entladen wird nur bei entspechender Vorhersage anwenden
+                            # Um das setzen der Akkuschonung zu verhindern, wenn aktuellePVProduktion zu wenig oder der Akku wieder entladen wird.
                             if (AkkuschonungLadewert < aktuellerLadewert or AkkuschonungLadewert < alterLadewert + 10) and aktuellePVProduktion * HysteProdFakt > AkkuschonungLadewert:
                                 aktuellerLadewert = AkkuschonungLadewert
                                 WRSchreibGrenze_nachUnten = aktuellerLadewert / 5

--- a/html/4_Hilfe.html
+++ b/html/4_Hilfe.html
@@ -191,10 +191,11 @@ td {font-size: 160%;
 <tr><td><input type="hidden" name="Zeile[41][0]" value=''>GrenzwertGroestePrognose</td>
 <td><input type="text" name="Zeile[41][1]" value="2000" readonly></td></tr>
 <tr><td colspan="2"><input type="hidden" name="Zeile[42]" value='' ></td></tr>
-<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[43]" value='' >; Akkuschonung (0=aus, 0.1 bis 1.0 ein) dadurch wird der Akku zwischen 80 und 95% mit 0,2C bzw. 0,1C geladen</td></tr>
-<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[43]" value='' >; Ab 95% wir mit 0,1C mal Akkuschonung (z.B.: 0.1x0.5 = 0.05C) geladen </td></tr>
-<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[44]" value=''>; und BattVollUm wird um eine Stunde vor verlegt, da am Schluss nicht mehr so stark geladen wird.</td></tr>
-<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[45]" value='' >; ACHTUNG: Eine Überschreitung der Einspeisegrenze bzw. AC-Leistung des WR setzt die Akkuschonung aus!</td></tr>
+<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[43]" value='' >
+; Akkuschonung (0=aus, 1=ein) <br>
+; Wenn Akkuschonung ein, wird BattVollUm um eine Stunde vor verlegt, da am Schluss nicht mehr so stark geladen wird.<br>
+; ACHTUNG: Eine Überschreitung der Einspeisegrenze bzw. AC-Leistung des WR setzt die Akkuschonung aus!<br>
+</td></tr>
 <tr><td><input type="hidden" name="Zeile[46][0]" value=''>Akkuschonung</td>
 <td><input type="text" name="Zeile[46][1]" value="1" readonly></td></tr>
 <tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[46]" value='' >; Hier können mehrere Ladebegrenzungen für die Akkuschonung definiert werden. 

--- a/html/4_Hilfe.html
+++ b/html/4_Hilfe.html
@@ -197,6 +197,12 @@ td {font-size: 160%;
 <tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[45]" value='' >; ACHTUNG: Eine Überschreitung der Einspeisegrenze bzw. AC-Leistung des WR setzt die Akkuschonung aus!</td></tr>
 <tr><td><input type="hidden" name="Zeile[46][0]" value=''>Akkuschonung</td>
 <td><input type="text" name="Zeile[46][1]" value="1" readonly></td></tr>
+<tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[46]" value='' >; Hier können mehrere Ladebegrenzungen für die Akkuschonung definiert werden. 
+<br>; Syntax: "Ladestand in Prozent" : "Ladeverhältnis zur Ladekapazietät des Akku"
+<br>; Akkuschonung_Werte = {"Ladestand%" : "LadewertC", ...}
+</td></tr>
+<tr><td><input type="hidden" name="Zeile[47][0]" value='Akkuschonung_Werte = '>Akkuschonung_Werte</td>
+<td><input type="text" name="Zeile[47][1]" value="{&quot;90&quot;: &quot;0.1&quot;, &quot;80&quot;: &quot;0.2&quot;, &quot;95&quot;: &quot;0.05&quot;}" readonly=""></td></tr>
 <tr><td colspan="2"><input type="hidden" name="Zeile[47]" value='' ></td></tr>
 <tr><th colspan="2"><input type="hidden" name="Zeile[53]" value='' >[monats_priv.ini]</th></tr>
 <tr class="comment"><td colspan="2"><input type="hidden" name="Zeile[54]" value='' >; hier können die Namen von zusätzlichen monatsabhängigen config.ini definiert werden.</td></tr>

--- a/html/4_tab_config_ini.php
+++ b/html/4_tab_config_ini.php
@@ -74,7 +74,7 @@ td {font-size: 160%;
   <div class="hilfe"> <a href="4_Hilfe.html"><b>Hilfe</b></a></div>
 <div class="version" align="center">
 <br>
-<b>  GEN24_Ladesteuerung Version: 0.24.7 </b>
+<b>  GEN24_Ladesteuerung Version: 0.24.8 </b>
 </div>
 <?php
 include "config.php";
@@ -125,7 +125,7 @@ function config_lesen( $file, $readonly )
                     $Zeilenteil[0] = ltrim(rtrim($Zeilenteil[0]));
                     $Zeilenteil[1] = ltrim(rtrim($Zeilenteil[1]));
                     echo '<tr><td><input type="hidden" name="Zeile['.$Zeilencounter.'][0]" value=\''.$Zeilenteil[0].' = \'>'.$Zeilenteil[0].'</td>'."\n";
-                    echo '<td><input type="text" name="Zeile['.$Zeilencounter.'][1]" value="'.$Zeilenteil[1].'" '.$readonly.'></td></tr>'."\n";
+                    echo '<td><input type="text" name="Zeile['.$Zeilencounter.'][1]" value="'.htmlentities($Zeilenteil[1]).'" '.$readonly.'></td></tr>'."\n";
                 } else {
                     #hier noch die Leerzeilen behandeln
                     $Zeile = rtrim($Zeile);

--- a/http_SymoGen24Controller2.py
+++ b/http_SymoGen24Controller2.py
@@ -232,37 +232,15 @@ if __name__ == '__main__':
                             LadewertGrund = "BattStatusProz < MindBattLad"
     
                     # Wenn Akkuschonung > 0 ab 80% Batterieladung mit Ladewert runter fahren
-                    # HysteProdFakt = 2 da bei 1 häufig hin und her geschaltet wird
-                    HysteProdFakt = 2
                     if Akkuschonung > 0:
-                        Ladefaktor = 1
-                        BattStatusProz_Grenze = 100
-                        # Schaltverzoegerung neu 
-                        if (BattStatusProz >= 78 and ( abs((BattganzeLadeKapazWatt * 0.2) - alterLadewert) < 3 )) or BattStatusProz >= 80:
-                            Ladefaktor = 0.2
-                            AkkuSchonGrund = '80%, Ladewert = 0.2C'
-                            BattStatusProz_Grenze = 80
-                        if (BattStatusProz >= 88 and ( abs((BattganzeLadeKapazWatt * 0.1) - alterLadewert) < 3 )) or BattStatusProz >= 90:
-                            Ladefaktor = 0.1
-                            AkkuSchonGrund = '90%, Ladewert = 0.1C'
-                            BattStatusProz_Grenze = 90
-                        if (BattStatusProz >= 94 and ( abs((BattganzeLadeKapazWatt * 0.1* Akkuschonung) - alterLadewert) < 3 )) or BattStatusProz >= 95:
-                            Ladefaktor = 0.1 * Akkuschonung
-                            AkkuSchonGrund = '95%, Ladewert = ' + str(Ladefaktor) + 'C'
-                            BattStatusProz_Grenze = 95
-
-                        AkkuschonungLadewert = int(BattganzeLadeKapazWatt * Ladefaktor)
-                        # Bei Akkuschonung Schaltverzögerung (hysterese), wenn Ladewert ist bereits der Akkuschonwert (+/- 3W) BattStatusProz_Grenze 5% runter
-                        if ( abs(AkkuschonungLadewert - alterLadewert) < 3 ):
-                            BattStatusProz_Grenze = BattStatusProz_Grenze * 0.95
-                            HysteProdFakt = 5
+                        Akkuschonung_dict = progladewert.getAkkuschonWert(BattStatusProz, BattganzeLadeKapazWatt, alterLadewert, aktuellerLadewert)
+                        AkkuschonungLadewert = Akkuschonung_dict[0]
+                        HysteProdFakt = Akkuschonung_dict[1]
+                        BattStatusProz_Grenze = Akkuschonung_dict[2]
+                        AkkuSchonGrund = Akkuschonung_dict[3]
+                        DEBUG_Ausgabe += Akkuschonung_dict[4]
 
                         if BattStatusProz >= BattStatusProz_Grenze:
-                            DEBUG_Ausgabe += "\nDEBUG <<<<<< Meldungen von Akkuschonung >>>>>>> "
-                            DEBUG_Ausgabe += "\nDEBUG AkkuschonungLadewert-alterLadewert: " + str(abs(AkkuschonungLadewert - alterLadewert))
-                            DEBUG_Ausgabe += "\nDEBUG BattStatusProz_Grenze: " + str(BattStatusProz_Grenze)
-                            DEBUG_Ausgabe += "\nDEBUG AkkuschonungLadewert: " + str(AkkuschonungLadewert) + "\n"
-                            DEBUG_Ausgabe += "DEBUG aktuellerLadewert: " + str(aktuellerLadewert) + "\n"
                             # Um das setzen der Akkuschonung zu verhindern, wenn aktuellePVProduktion zu wenig oder der Akku wieder entladen wird.
                             if (AkkuschonungLadewert < aktuellerLadewert or AkkuschonungLadewert < alterLadewert + 10) and aktuellePVProduktion * HysteProdFakt > AkkuschonungLadewert:
                                 aktuellerLadewert = AkkuschonungLadewert


### PR DESCRIPTION
Akkuschonung frei konfigurierbar machen.

Beispiel aus der CONFIG/charge.ini:
```
; Akkuschonung_Werte = {"Ladestand%" : "LadewertC", ...}
Akkuschonung_Werte = {"80": "0.2", "90": "0.1", "95": "0.05"}
```