### PR TITLE
v0.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 **[0.27.1] – 2025-XX-XX**  
 
+DynamicPriceCheck.py:
+- **Neuer Parameter in CONFIG/dynprice.ini** `netzlade_preisschwelle`.   
+  Bei einem Strompreis unter diesem Preis, wird immer versucht den Akku voll zuladen (z.B. negative Strompreise, oder unter Einspeisevergütung).  
 
+FIX: Erste node in response von /components/readable statt fest auf '0' gehen, da auch '1' als erster Node vorkommen kann.  
 
 **[0.27.0] – 2025-04-07**  
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ DynamicPriceCheck.py:
 - **Neuer Parameter in CONFIG/dynprice.ini** `netzlade_preisschwelle`.   
   Bei einem Strompreis unter diesem Preis, wird immer versucht den Akku voll zuladen (z.B. negative Strompreise, oder unter Einspeisevergütung).  
 
+- Strompreis-Chart: Hier wird nun auch der reine Börsenpreis dargestellt.
+
 FIX: Erste node in response von /components/readable statt fest auf '0' gehen, da auch '1' als erster Node vorkommen kann.  
 
 **[0.27.0] – 2025-04-07**  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**[0.27.1] – 2025-XX-XX**  
+
+
+
 **[0.27.0] – 2025-04-07**  
 
 - Weiterentwicklung der Grafana Dashboards und der Beschreibung von @Manniene

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-**[0.27.1] – 2025-XX-XX**  
+**[0.27.1] – 2025-04-13**  
 
 DynamicPriceCheck.py:
 - **Neuer Parameter in CONFIG/dynprice.ini** `netzlade_preisschwelle`.   

--- a/CONFIG/dynprice.ini
+++ b/CONFIG/dynprice.ini
@@ -25,6 +25,8 @@ Lade_Verbrauchs_Faktor = 1.1
 Gewinnerwartung_kW  = 0.05
 ; Bis zu wieviel Prozent darf der Akku aus dem Netz geladen werden
 max_batt_dyn_ladung = 99
+; Preis, unter dem der Akku immer zwangsgeladen wird
+netzlade_preisschwelle = 0
 
 ; Infos siehe https://api.energy-charts.info/
 Preisquelle = energycharts

--- a/CONFIG/dynprice.ini
+++ b/CONFIG/dynprice.ini
@@ -20,13 +20,13 @@ charge_rate_kW = 4000
 Akku_Verlust_Prozent = 15
 ; Ladung anpassen durch Pufferfaktor, der auf den Verbrauch aus dem Lastprofil angewendet wird
 Lade_Verbrauchs_Faktor = 1.1
-; Um den Wert Gewinnerwartung_kWh muss der Preis Pro kWh bei 
+; Um den Wert Gewinnerwartung_kWh muss der Preis in EURO/kWh bei 
 ; Speicherung in den Akku nach Abzug von Akku_Verlust_Prozent mindestens niedriger sein.
 Gewinnerwartung_kW  = 0.05
 ; Bis zu wieviel Prozent darf der Akku aus dem Netz geladen werden
 max_batt_dyn_ladung = 99
-; Preis, unter dem der Akku immer zwangsgeladen wird
-netzlade_preisschwelle = 0
+; Preis, in EURO unter dem der Akku immer zwangsgeladen wird (kann auch Minuswert sein)
+netzlade_preisschwelle = 0.00
 
 ; Infos siehe https://api.energy-charts.info/
 Preisquelle = energycharts

--- a/FUNCTIONS/GEN24_API.py
+++ b/FUNCTIONS/GEN24_API.py
@@ -16,12 +16,13 @@ class gen24api:
         url = requests.get(gen24url)
         text = url.text
         data = json.loads(text)
+        first_node = next(iter(data['Body']['Data']))
         API = {}
         # "393216 OR 0 -  channels - BAT_MODE_ENFORCED_U16" : 2.0, AKKU AUS
         # "393216 OR 0 -  channels - BAT_MODE_ENFORCED_U16" : 0.0, AKKU EIN
         try:
             # API ab Firmware 1.35.4-1
-            API['BAT_MODE'] = data['Body']['Data']['0']['channels']['BAT_MODE_ENFORCED_U16'] 
+            API['BAT_MODE'] = data['Body']['Data'][first_node]['channels']['BAT_MODE_ENFORCED_U16'] 
             if API['BAT_MODE'] != 2:
                 # Aktuelle Werte für Prognoseberechung
                 attributes_nameplate = json.loads(data['Body']['Data']['16580608']['attributes']['nameplate'])
@@ -35,21 +36,21 @@ class gen24api:
                 API['aktuelleEinspeisung'] = int(data['Body']['Data']['16252928']['channels']['SMARTMETER_POWERACTIVE_MEAN_SUM_F64'])
                 # PV_POWERACTIVE_MEAN_02_F32 existiert nicht, wenn nur ein String am GEN24 hängt
                 try:
-                    API_STRING2 = data['Body']['Data']['0']['channels']['PV_POWERACTIVE_MEAN_02_F32']
+                    API_STRING2 = data['Body']['Data'][first_node]['channels']['PV_POWERACTIVE_MEAN_02_F32']
                 except:
                     API_STRING2 = 0
-                API['aktuellePVProduktion'] = int(data['Body']['Data']['0']['channels']['PV_POWERACTIVE_MEAN_01_F32'] + API_STRING2)
-                API['aktuelleBatteriePower'] = int(data['Body']['Data']['0']['channels']['BAT_POWERACTIVE_MEAN_F32'])
+                API['aktuellePVProduktion'] = int(data['Body']['Data'][first_node]['channels']['PV_POWERACTIVE_MEAN_01_F32'] + API_STRING2)
+                API['aktuelleBatteriePower'] = int(data['Body']['Data'][first_node]['channels']['BAT_POWERACTIVE_MEAN_F32'])
                 API['BatteryMaxDischargePercent'] = ''
                 # Zählerstände fürs Logging
-                API['AC_Produktion'] =  int((data['Body']['Data']['0']['channels']['ACBRIDGE_ENERGYACTIVE_PRODUCED_SUM_01_U64']+data['Body']['Data']['0']['channels']['ACBRIDGE_ENERGYACTIVE_PRODUCED_SUM_02_U64']+\
-                    data['Body']['Data']['0']['channels']['ACBRIDGE_ENERGYACTIVE_PRODUCED_SUM_03_U64'])/3600)
-                API['DC_Produktion'] =  int((data['Body']['Data']['0']['channels']['PV_ENERGYACTIVE_ACTIVE_SUM_01_U64']+ data['Body']['Data']['0']['channels']['PV_ENERGYACTIVE_ACTIVE_SUM_02_U64'])/3600)
-                API['AC_to_DC'] = int((data['Body']['Data']['0']['channels']['ACBRIDGE_ENERGYACTIVE_ACTIVECONSUMED_SUM_01_U64'] +\
-                    data['Body']['Data']['0']['channels']['ACBRIDGE_ENERGYACTIVE_ACTIVECONSUMED_SUM_02_U64'] +\
-                    data['Body']['Data']['0']['channels']['ACBRIDGE_ENERGYACTIVE_ACTIVECONSUMED_SUM_03_U64'])/3600)
-                API['Batterie_IN'] =    int(data['Body']['Data']['0']['channels']['BAT_ENERGYACTIVE_ACTIVECHARGE_SUM_01_U64']/3600)
-                API['Batterie_OUT'] =   int(data['Body']['Data']['0']['channels']['BAT_ENERGYACTIVE_ACTIVEDISCHARGE_SUM_01_U64']/3600)
+                API['AC_Produktion'] =  int((data['Body']['Data'][first_node]['channels']['ACBRIDGE_ENERGYACTIVE_PRODUCED_SUM_01_U64']+data['Body']['Data'][first_node]['channels']['ACBRIDGE_ENERGYACTIVE_PRODUCED_SUM_02_U64']+\
+                    data['Body']['Data'][first_node]['channels']['ACBRIDGE_ENERGYACTIVE_PRODUCED_SUM_03_U64'])/3600)
+                API['DC_Produktion'] =  int((data['Body']['Data'][first_node]['channels']['PV_ENERGYACTIVE_ACTIVE_SUM_01_U64']+ data['Body']['Data'][first_node]['channels']['PV_ENERGYACTIVE_ACTIVE_SUM_02_U64'])/3600)
+                API['AC_to_DC'] = int((data['Body']['Data'][first_node]['channels']['ACBRIDGE_ENERGYACTIVE_ACTIVECONSUMED_SUM_01_U64'] +\
+                    data['Body']['Data'][first_node]['channels']['ACBRIDGE_ENERGYACTIVE_ACTIVECONSUMED_SUM_02_U64'] +\
+                    data['Body']['Data'][first_node]['channels']['ACBRIDGE_ENERGYACTIVE_ACTIVECONSUMED_SUM_03_U64'])/3600)
+                API['Batterie_IN'] =    int(data['Body']['Data'][first_node]['channels']['BAT_ENERGYACTIVE_ACTIVECHARGE_SUM_01_U64']/3600)
+                API['Batterie_OUT'] =   int(data['Body']['Data'][first_node]['channels']['BAT_ENERGYACTIVE_ACTIVEDISCHARGE_SUM_01_U64']/3600)
                 API['Netzverbrauch'] =  int(data['Body']['Data']['16252928']['channels']['SMARTMETER_ENERGYACTIVE_CONSUMED_SUM_F64'])
                 API['Einspeisung'] =    int(data['Body']['Data']['16252928']['channels']['SMARTMETER_ENERGYACTIVE_PRODUCED_SUM_F64'])
         except:
@@ -91,20 +92,21 @@ class gen24api:
                     url = requests.get(gen24url)
                     text = url.text
                     data = json.loads(text)
+                    first_node = next(iter(data['Body']['Data']))
                     try:
                         # API ab Firmware 1.35.4-1
                         # PV_POWERACTIVE_MEAN_02_F32 xirstiert nicht, wenn nur ein String am GEN24 hängt
                         try:
-                            API_STRING2 = data['Body']['Data']['0']['channels']['PV_POWERACTIVE_MEAN_02_F32']
+                            API_STRING2 = data['Body']['Data'][first_node]['channels']['PV_POWERACTIVE_MEAN_02_F32']
                         except:
                             API_STRING2 = 0
-                        API['aktuellePVProduktion'] = int(data['Body']['Data']['0']['channels']['PV_POWERACTIVE_MEAN_01_F32'] + API_STRING2)
-                        API['AC_Produktion'] += int((data['Body']['Data']['0']['channels']['ACBRIDGE_ENERGYACTIVE_PRODUCED_SUM_01_U64']+data['Body']['Data']['0']['channels']['ACBRIDGE_ENERGYACTIVE_PRODUCED_SUM_02_U64']+\
-                            data['Body']['Data']['0']['channels']['ACBRIDGE_ENERGYACTIVE_PRODUCED_SUM_03_U64'])/3600)
-                        API['DC_Produktion'] += int((data['Body']['Data']['0']['channels']['PV_ENERGYACTIVE_ACTIVE_SUM_01_U64']+ data['Body']['Data']['0']['channels']['PV_ENERGYACTIVE_ACTIVE_SUM_02_U64'])/3600)
-                        API['AC_to_DC'] = int((data['Body']['Data']['0']['channels']['ACBRIDGE_ENERGYACTIVE_ACTIVECONSUMED_SUM_01_U64'] +\
-                            data['Body']['Data']['0']['channels']['ACBRIDGE_ENERGYACTIVE_ACTIVECONSUMED_SUM_02_U64'] +\
-                            data['Body']['Data']['0']['channels']['ACBRIDGE_ENERGYACTIVE_ACTIVECONSUMED_SUM_03_U64'])/3600)
+                        API['aktuellePVProduktion'] = int(data['Body']['Data'][first_node]['channels']['PV_POWERACTIVE_MEAN_01_F32'] + API_STRING2)
+                        API['AC_Produktion'] += int((data['Body']['Data'][first_node]['channels']['ACBRIDGE_ENERGYACTIVE_PRODUCED_SUM_01_U64']+data['Body']['Data'][first_node]['channels']['ACBRIDGE_ENERGYACTIVE_PRODUCED_SUM_02_U64']+\
+                            data['Body']['Data'][first_node]['channels']['ACBRIDGE_ENERGYACTIVE_PRODUCED_SUM_03_U64'])/3600)
+                        API['DC_Produktion'] += int((data['Body']['Data'][first_node]['channels']['PV_ENERGYACTIVE_ACTIVE_SUM_01_U64']+ data['Body']['Data'][first_node]['channels']['PV_ENERGYACTIVE_ACTIVE_SUM_02_U64'])/3600)
+                        API['AC_to_DC'] = int((data['Body']['Data'][first_node]['channels']['ACBRIDGE_ENERGYACTIVE_ACTIVECONSUMED_SUM_01_U64'] +\
+                            data['Body']['Data'][first_node]['channels']['ACBRIDGE_ENERGYACTIVE_ACTIVECONSUMED_SUM_02_U64'] +\
+                            data['Body']['Data'][first_node]['channels']['ACBRIDGE_ENERGYACTIVE_ACTIVECONSUMED_SUM_03_U64'])/3600)
                     except:
                         # API vor Firmware 1.35.4-1
                         API['aktuellePVProduktion'] += int(data['Body']['Data']['262144']['channels']['PV_POWERACTIVE_SUM_F64'])

--- a/html/4_tab_config_ini.php
+++ b/html/4_tab_config_ini.php
@@ -74,7 +74,7 @@ td {font-size: 160%;
   <div class="hilfe"> <a href="4_Hilfe.html"><b>Hilfe</b></a></div>
 <div class="version" align="center">
 <br>
-<b>  GEN24_Ladesteuerung Version: 0.27.0 </b>
+<b>  GEN24_Ladesteuerung Version: 0.27.1 </b>
 </div>
 <?php
 include "config.php";

--- a/html/7_funktion_Diagram.php
+++ b/html/7_funktion_Diagram.php
@@ -21,10 +21,18 @@ $morgen =  date("Y-m-d 00:00",(strtotime("+1 day", strtotime(date("Y-m-d")))));
 
 # Schalter am Anfang und am Ende deaktivieren
 $button_vor_on = '';
-if (strtotime($DiaDatenBis) > strtotime($DBletzterTag)) $button_vor_on = 'disabled';
+$PfeilGrauton_vor = '1.0';
+$PfeilGrauton_back = '1.0';
+if (strtotime($DiaDatenBis) > strtotime($DBletzterTag)) {
+    $button_vor_on = 'disabled';
+    $PfeilGrauton_vor = '0.3';
+};
 # Schalter für Tag out of DB  deaktivieren
 $button_back_on = '';
-if (strtotime($DiaDatenVon) <= strtotime($DBersterTag)) $button_back_on = 'disabled';
+if (strtotime($DiaDatenVon) <= strtotime($DBersterTag)) {
+    $button_back_on = 'disabled';
+    $PfeilGrauton_back = '0.3';
+};
 
 # Schalter zum Blättern usw.
 echo '<table><tr><td>';
@@ -34,7 +42,7 @@ echo '<input type="hidden" name="DiaDatenBis" value="'.$VOR_DiaDatenBis.'">'."\n
 echo '<input type="hidden" name="Zeitraum" value="'.$Zeitraum.'">'."\n";
 echo '<input type="hidden" name="AnfangVon" value="'.$GLOBALS['_POST']['AnfangVon'].'">'."\n";
 echo '<input type="hidden" name="AnfangBis" value="'.$GLOBALS['_POST']['AnfangBis'].'">'."\n";
-echo '<button type="submit" class="navi" '.$button_back_on.'> &nbsp;&lt;&lt;&nbsp;</button>';
+echo '<button type="submit" style="opacity: '.$PfeilGrauton_back.'" class="navi" '.$button_back_on.'> &nbsp;&lt;&lt;&nbsp;</button>';
 echo '</form>'."\n";
 
 echo '</td><td>';
@@ -54,7 +62,7 @@ echo '<input type="hidden" name="DiaDatenBis" value="'.$NACH_DiaDatenBis.'">'."\
 echo '<input type="hidden" name="Zeitraum" value="'.$Zeitraum.'">'."\n";
 echo '<input type="hidden" name="AnfangVon" value="'.$GLOBALS['_POST']['AnfangVon'].'">'."\n";
 echo '<input type="hidden" name="AnfangBis" value="'.$GLOBALS['_POST']['AnfangBis'].'">'."\n";
-echo '<button type="submit" class="navi" '.$button_vor_on.'> &nbsp;&gt;&gt;&nbsp; </button>';
+echo '<button type="submit" style="opacity: '.$PfeilGrauton_vor.'" class="navi" '.$button_vor_on.'> &nbsp;&gt;&gt;&nbsp; </button>';
 echo '</form>'."\n";
 
 echo '</td><td style="text-align:center; width: 100%;">';

--- a/html/8_funktion_Diagram.php
+++ b/html/8_funktion_Diagram.php
@@ -40,11 +40,19 @@ if ( $diff->y == 0 AND $diff->m == 0 AND $diff->d == 1) {
 
 # Schalter am Anfang und am Ende deaktivieren
 $button_vor_on = '';
+$PfeilGrauton_vor = '1.0';
+$PfeilGrauton_back = '1.0';
 $heute = date("Y-m-d H:i");
-if (strtotime($DiaDatenBis) >= strtotime($heute)) $button_vor_on = 'disabled';
+if (strtotime($DiaDatenBis) >= strtotime($heute)) {
+    $button_vor_on = 'disabled';
+    $PfeilGrauton_vor = '0.3';
+};
 # Schalter für Tag out of DB  deaktivieren
 $button_back_on = '';
-if (strtotime($DiaDatenVon) <= strtotime($DBersterTag)) $button_back_on = 'disabled';
+if (strtotime($DiaDatenVon) <= strtotime($DBersterTag)) {
+    $button_back_on = 'disabled';
+    $PfeilGrauton_back = '0.3';
+};
 
 # Schalter zum Blättern usw.
 echo '<table><tr><td>';
@@ -55,7 +63,7 @@ echo '<input type="hidden" name="diagramtype" value="'.$diagramtype.'">'."\n";
 echo '<input type="hidden" name="Zeitraum" value="'.$Zeitraum.'">'."\n";
 echo '<input type="hidden" name="AnfangVon" value="'.$GLOBALS['_POST']['AnfangVon'].'">'."\n";
 echo '<input type="hidden" name="AnfangBis" value="'.$GLOBALS['_POST']['AnfangBis'].'">'."\n";
-echo '<button type="submit" class="navi" '.$button_back_on.'> &nbsp;&lt;&lt;&nbsp;</button>';
+echo '<button type="submit" style="opacity: '.$PfeilGrauton_back.'" class="navi" '.$button_back_on.'> &nbsp;&lt;&lt;&nbsp;</button>';
 echo '</form>'."\n";
 
 echo '</td><td>';
@@ -77,7 +85,7 @@ echo '<input type="hidden" name="diagramtype" value="'.$diagramtype.'">'."\n";
 echo '<input type="hidden" name="Zeitraum" value="'.$Zeitraum.'">'."\n";
 echo '<input type="hidden" name="AnfangVon" value="'.$GLOBALS['_POST']['AnfangVon'].'">'."\n";
 echo '<input type="hidden" name="AnfangBis" value="'.$GLOBALS['_POST']['AnfangBis'].'">'."\n";
-echo '<button type="submit" class="navi" '.$button_vor_on.'> &nbsp;&gt;&gt;&nbsp; </button>';
+echo '<button type="submit" style="opacity: '.$PfeilGrauton_vor.'" class="navi" '.$button_vor_on.'> &nbsp;&gt;&gt;&nbsp; </button>';
 echo '</form>'."\n";
 
 echo '</td><td style="text-align:center; width: 100%;">';

--- a/html/config.php
+++ b/html/config.php
@@ -26,7 +26,8 @@ $TAB_config = array (
 # Optionen für das Strompreisdiagramm
 $Strompreis_Dia_optionen = array();
 $Strompreis_Dia_optionen['BattStatus']=['Farbe'=>'rgba(72,118,255,1)','fill'=>'false','stack'=>'1','linewidth'=>'4','order'=>'0','yAxisID'=>'y2','hidden'=>'false','type'=>'line','unit'=>'%','showLabel'=>'false','decimals'=>'1'];
-$Strompreis_Dia_optionen['Bruttopreis']=['Farbe'=>'rgba(255,51,51,1)','fill'=>'false','stack'=>'3','linewidth'=>'0','order'=>'0','yAxisID'=>'y3','hidden'=>'false','type'=>'bar','unit'=>'ct','showLabel'=>'true','decimals'=>'1'];
+$Strompreis_Dia_optionen['Boersenpreis']=['Farbe'=>'rgba(255,51,51,0.6)','fill'=>'false','stack'=>'3','linewidth'=>'0','order'=>'0','yAxisID'=>'y3','hidden'=>'false','type'=>'bar','unit'=>'ct','showLabel'=>'false','decimals'=>'1'];
+$Strompreis_Dia_optionen['Preisaufschlag']=['Farbe'=>'rgba(255,51,51,1)','fill'=>'false','stack'=>'3','linewidth'=>'0','order'=>'0','yAxisID'=>'y3','hidden'=>'false','type'=>'bar','unit'=>'ct','showLabel'=>'true','decimals'=>'1'];
 $Strompreis_Dia_optionen['Netzladen']=['Farbe'=>'rgba(60,215,60,1)','fill'=>'true','stack'=>'2','linewidth'=>'0','order'=>'4','yAxisID'=>'y','hidden'=>'false','type'=>'bar','unit'=>'W','showLabel'=>'false','decimals'=>'0'];
 $Strompreis_Dia_optionen['Netzverbrauch']=['Farbe'=>'rgba(110,110,110,1)','fill'=>'true','stack'=>'2','linewidth'=>'0','order'=>'2','yAxisID'=>'y','hidden'=>'false','type'=>'bar','unit'=>'W','showLabel'=>'false','decimals'=>'0'];
 $Strompreis_Dia_optionen['Vorhersage']=['Farbe'=>'rgba(255,140,05,1)','fill'=>'false','stack'=>'0','linewidth'=>'4','order'=>'0','yAxisID'=>'y','hidden'=>'false','type'=>'line','unit'=>'W','showLabel'=>'false','decimals'=>'0'];


### PR DESCRIPTION
FIX in  FUNKTIONS/GEN24_API.py:
- Erster Node in response von /components/readable statt fest auf '0' gehen, da auch '1' als erster Node vorkommen kann.
  Vielleicht kann das mal jemand, der noch eine Version vor Firmware 1.35.4-1 hat testen.

- **Neuer Parameter in CONFIG/dynprice.ini** `netzlade_preisschwelle`.
  Bei einem Strompreis unter diesem Preis, wird immer versucht den Akku voll zuladen (z.B. negative Strompreise, oder unter Einspeisevergütung).

