### PR TITLE
Forecast.solar erweitern um damping (alle) und actual (nur mit api Key)

### DIFF
--- a/CONFIG/weather.ini
+++ b/CONFIG/weather.ini
@@ -20,7 +20,7 @@ api_key = kein
 ; wenn ein API key vorhanden ist, koennen die Forecasts mit aktuellen Ertragswerten des Tages verbessert werden. "ja" passt diese an, "nein" nutzt diese Funktion der API nicht. Siehe https://doc.forecast.solar/actual
 forecastactual = ja
 ; wenn "damping" eingesetzt werden soll, hier die entsprechenden Werte einstellen. "0,0" bedeutet kein Damping. Siehe https://doc.forecast.solar/damping
-forecastdamping = "0,0"
+forecastdamping = 0,0
 ; Wenn ein api_pers_plus vorhanden ist (api_pers_plus = ja) können zwei Ausrichtungen in einer Abrfage behandelt werden.
 api_pers_plus = nein
 lat = 44.444

--- a/CONFIG/weather.ini
+++ b/CONFIG/weather.ini
@@ -17,11 +17,14 @@ anzahl = 1
 weatherfile = weatherData.json
 ; Wenn api_key nicht 'kein' ist, wird er für die Prognoseabfrage verwendet.
 api_key = kein
-; wenn ein API key vorhanden ist, koennen die Forecasts mit aktuellen Ertragswerten des Tages verbessert werden. "ja" passt diese an, "nein" nutzt diese Funktion der API nicht. Siehe https://doc.forecast.solar/actual
+; wenn ein API key vorhanden ist, koennen die Forecasts mit aktuellen Ertragswerten des Tages verbessert werden.
+; 'ja' nutzt diese Funktion der API, 'nein' nicht.
+; Siehe https://doc.forecast.solar/actual
 forecastactual = ja
-; wenn "damping" eingesetzt werden soll, hier die entsprechenden Werte einstellen. Siehe https://doc.forecast.solar/damping
+; wenn "damping" eingesetzt werden soll, hier die entsprechenden Werte einstellen. '0,0' ist Standardwert (kein Damping)
 ; 0,0 bedeutet kein Damping, 0.25,0.75 bedeutet etwas damping am Morgen, hohes Damping am nachmittag.
 ; beide Werte müssen zwischen 0 und 1 sein
+; Siehe https://doc.forecast.solar/damping
 forecastdamping = 0,0
 ; Wenn ein api_pers_plus vorhanden ist (api_pers_plus = ja) können zwei Ausrichtungen in einer Abrfage behandelt werden.
 api_pers_plus = nein

--- a/CONFIG/weather.ini
+++ b/CONFIG/weather.ini
@@ -28,6 +28,7 @@ forecastactual = ja
 forecastdamping = 0,0
 ; Wenn ein api_pers_plus vorhanden ist (api_pers_plus = ja) können zwei Ausrichtungen in einer Abrfage behandelt werden.
 api_pers_plus = nein
+; lat und lon sind die Positionsdaten der Anlage bzw. des Strings. Nutze https://www.suncalc.org/ oder andere Tools zur Identifikation
 lat = 44.444
 lon = 11.111
 ; horizon gibt mögliche Verschattungen pro String an:
@@ -36,12 +37,18 @@ lon = 11.111
 ; wenn zum Beipiel im Südwesten ein großer Baum Schatten wirft:
 ; 0,0,0,0,0,0,0,20,45,20,0,0
 horizon = 0,0,0,0,0,0,0,0,0,0,0,0
+; dec ist der Winkel, in dem die Module verbaut sind, wobei 0 waagerecht liegen und 90 senkrecht stehend bedeutet
 dec = 30
+; az ist der Azimuth der Anlage, also in welche Himmelsrichtung die Module ausgerichtet. -180 und 180 = Norden, -90 = Osten, 0 = Sueden, 90 = Westen
 az = 0
+; kwp ist installierte Leistung der Module in kWp
 kwp = 11.4
+; Wert in Minuten, bis bisherige Daten ihre Gültigkeit verlieren und neue von der API abgerufen werden sollen
+; aktuell gueltige Werte fuer die Anzahl an API Aufrufen pro 60 Minuten findet man unter https://doc.forecast.solar/account_models
 dataAgeMaxInMinutes = 100
 
 [forecast.solar2]
+; hier die Werte des zweiten Strings angeben, wenn vorhanden
 horizon = 0,0,0,0,0,0,0,0,0,0,0,0
 dec = 22
 az = 135

--- a/CONFIG/weather.ini
+++ b/CONFIG/weather.ini
@@ -17,6 +17,10 @@ anzahl = 1
 weatherfile = weatherData.json
 ; Wenn api_key nicht 'kein' ist, wird er für die Prognoseabfrage verwendet.
 api_key = kein
+; wenn ein API key vorhanden ist, koennen die Forecasts mit aktuellen Ertragswerten des Tages verbessert werden. "ja" passt diese an, "nein" nutzt diese Funktion der API nicht. Siehe https://doc.forecast.solar/actual
+forecastactual = ja
+; wenn "damping" eingesetzt werden soll, hier die entsprechenden Werte einstellen. "0,0" bedeutet kein Damping. Siehe https://doc.forecast.solar/damping
+forecastdamping = "0,0"
 ; Wenn ein api_pers_plus vorhanden ist (api_pers_plus = ja) können zwei Ausrichtungen in einer Abrfage behandelt werden.
 api_pers_plus = nein
 lat = 44.444

--- a/CONFIG/weather.ini
+++ b/CONFIG/weather.ini
@@ -19,7 +19,9 @@ weatherfile = weatherData.json
 api_key = kein
 ; wenn ein API key vorhanden ist, koennen die Forecasts mit aktuellen Ertragswerten des Tages verbessert werden. "ja" passt diese an, "nein" nutzt diese Funktion der API nicht. Siehe https://doc.forecast.solar/actual
 forecastactual = ja
-; wenn "damping" eingesetzt werden soll, hier die entsprechenden Werte einstellen. "0,0" bedeutet kein Damping. Siehe https://doc.forecast.solar/damping
+; wenn "damping" eingesetzt werden soll, hier die entsprechenden Werte einstellen. Siehe https://doc.forecast.solar/damping
+; 0,0 bedeutet kein Damping, 0.25,0.75 bedeutet etwas damping am Morgen, hohes Damping am nachmittag.
+; beide Werte müssen zwischen 0 und 1 sein
 forecastdamping = 0,0
 ; Wenn ein api_pers_plus vorhanden ist (api_pers_plus = ja) können zwei Ausrichtungen in einer Abrfage behandelt werden.
 api_pers_plus = nein

--- a/CONFIG/weather.ini
+++ b/CONFIG/weather.ini
@@ -30,12 +30,19 @@ forecastdamping = 0,0
 api_pers_plus = nein
 lat = 44.444
 lon = 11.111
+; horizon gibt mögliche Verschattungen pro String an:
+; die 12 Zahlen werden in Grad angegeben und repräsentieren im Uhrzeigersinn in 30 Grad Schritten, beginnen bei Nord, den Horizont
+; siehe https://doc.forecast.solar/horizon
+; wenn zum Beipiel im Südwesten ein großer Baum Schatten wirft:
+; 0,0,0,0,0,0,0,20,45,20,0,0
+horizon = 0,0,0,0,0,0,0,0,0,0,0,0
 dec = 30
 az = 0
 kwp = 11.4
 dataAgeMaxInMinutes = 100
 
 [forecast.solar2]
+horizon = 0,0,0,0,0,0,0,0,0,0,0,0
 dec = 22
 az = 135
 kwp = 4.44

--- a/FUNCTIONS/SQLall.py
+++ b/FUNCTIONS/SQLall.py
@@ -1,5 +1,6 @@
 # Funktionen für die Gen24_Ladesteuerung
 from datetime import datetime
+from datetime import date
 import sqlite3
 import json
     
@@ -62,6 +63,16 @@ class sqlall:
         DC_Produktion = row[0][1]
 
         return (AC_Produktion, DC_Produktion)
+
+    def getSQLcurrentDayProduction(self, database):
+        verbindung = sqlite3.connect(database)
+        zeiger = verbindung.cursor()
+        sql_anweisung = "SELECT MAX(DC_Produktion)- MIN(DC_Produktion) AS DC_Produktion from pv_daten where Zeitpunkt LIKE '" +date.today()+"%';"
+        zeiger.execute(sql_anweisung)
+        row = zeiger.fetchall()
+        currentDayProduction = round(row[0][0]/1000,1)
+
+        return (currentDayProduction)
 
     def getSQLsteuerdaten(self, schluessel):
         verbindung = sqlite3.connect('CONFIG/Prog_Steuerung.sqlite')

--- a/FUNCTIONS/SQLall.py
+++ b/FUNCTIONS/SQLall.py
@@ -67,7 +67,8 @@ class sqlall:
     def getSQLcurrentDayProduction(self, database):
         verbindung = sqlite3.connect(database)
         zeiger = verbindung.cursor()
-        sql_anweisung = "SELECT MAX(DC_Produktion)- MIN(DC_Produktion) AS DC_Produktion from pv_daten where Zeitpunkt LIKE '" +date.today()+"%';"
+        heute = date.today()
+        sql_anweisung = "SELECT MAX(DC_Produktion)- MIN(DC_Produktion) AS DC_Produktion from pv_daten where Zeitpunkt LIKE '" + heute.strftime("%Y-%m-%d")+"%';"
         zeiger.execute(sql_anweisung)
         row = zeiger.fetchall()
         currentDayProduction = round(row[0][0]/1000,1)

--- a/FUNCTIONS/SQLall.py
+++ b/FUNCTIONS/SQLall.py
@@ -1,6 +1,5 @@
 # Funktionen für die Gen24_Ladesteuerung
 from datetime import datetime
-from datetime import date
 import sqlite3
 import json
     
@@ -67,8 +66,7 @@ class sqlall:
     def getSQLcurrentDayProduction(self, database):
         verbindung = sqlite3.connect(database)
         zeiger = verbindung.cursor()
-        heute = date.today()
-        sql_anweisung = "SELECT MAX(DC_Produktion)- MIN(DC_Produktion) AS DC_Produktion from pv_daten where Zeitpunkt LIKE '" + heute.strftime("%Y-%m-%d")+"%';"
+        sql_anweisung = "SELECT MAX(DC_Produktion)- MIN(DC_Produktion) AS DC_Produktion from pv_daten where Zeitpunkt LIKE '" + self.now.strftime("%Y-%m-%d")+"%';"
         zeiger.execute(sql_anweisung)
         row = zeiger.fetchall()
         currentDayProduction = round(row[0][0]/1000,1)

--- a/WeatherDataProvider2.py
+++ b/WeatherDataProvider2.py
@@ -31,8 +31,8 @@ def loadLatestWeatherData():
 
     if api_pers_plus == 'ja' and anzahl_strings == 1:
         sqlall = FUNCTIONS.SQLall.sqlall()
-        currentDayProduction = sqlall.getSQLcurrentDayProduction()
-        url = url+'?actual=' +currentDayProduction
+        currentDayProduction = sqlall.getSQLcurrentDayProduction('PV_Daten.sqlite')
+        url = url+'?actual=' +"{:.1f}".format(currentDayProduction)
 
     try:
         try:

--- a/WeatherDataProvider2.py
+++ b/WeatherDataProvider2.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import requests
 import json
 import FUNCTIONS.functions
+import FUNCTIONS.SQLall
 
 def loadLatestWeatherData():
     api_key = basics.getVarConf('forecast.solar','api_key','str')
@@ -27,6 +28,11 @@ def loadLatestWeatherData():
         if anzahl_strings == 2 and api_pers_plus == 'ja':
             url = url_anfang+'/estimate/{}/{}/{}/{}/{}/{}/{}/{}'.format(lat, lon, dec, az, kwp, dec2, az2, kwp2)
             anzahl_strings = 1
+
+    if api_pers_plus == 'ja' and anzahl_strings == 1:
+        sqlall = FUNCTIONS.SQLall.sqlall()
+        currentDayProduction = sqlall.getSQLcurrentDayProduction()
+        url = url+'?actual=' +currentDayProduction
 
     try:
         try:

--- a/WeatherDataProvider2.py
+++ b/WeatherDataProvider2.py
@@ -31,7 +31,8 @@ def loadLatestWeatherData():
             url = url_anfang+'/estimate/{}/{}/{}/{}/{}/{}/{}/{}?damping={}'.format(lat, lon, dec, az, kwp, dec2, az2, kwp2, forecastdamping)
             anzahl_strings = 1
 
-    if forecastactual == "ja":
+    # actual nur wenn ein API key vorhanden ist
+    if api_key != 'kein' and forecastactual == 'ja':
         sqlall = FUNCTIONS.SQLall.sqlall()
         currentDayProduction = sqlall.getSQLcurrentDayProduction('PV_Daten.sqlite')
         url = url+'&actual=' +"{:.1f}".format(currentDayProduction)

--- a/WeatherDataProvider2.py
+++ b/WeatherDataProvider2.py
@@ -34,15 +34,21 @@ def loadLatestWeatherData():
             anzahl_strings = 1
 
     # resolution auf 60 Minuten, horizon und damping an die URL anhängen:
-    url = url+'?resolution=60&horizon={}&damping={}'.format(horizon, forecastdamping)
-    url2 = url2+'?resolution=60&horizon={}&damping={}'.format(horizon2, forecastdamping)
+    if api_pers_plus == 'ja' and basics.getVarConf('pv.strings','anzahl','eval') == 2:
+        # hier gibt es nur noch eine URL zu veraendern
+        url = url+'?resolution=60&horizon1={}&horizon2={}&damping={}'.format(horizon, horizon2, forecastdamping)
+    else:
+        # hier muessen beide URLs angepasst werden
+        url = url+'?resolution=60&horizon={}&damping={}'.format(horizon, forecastdamping)
+        url2 = url2+'?resolution=60&horizon={}&damping={}'.format(horizon2, forecastdamping)
 
     # actual nur wenn ein API key vorhanden ist
+    # Achtung: wenn durch eine Personal Subscription ein API Key vorhanden ist, aber keine Personal _PLUS_ Subscription, kann actual nicht bei beiden Abfragen genutzt werden, sonst verfälscht es die Werte, daher immer nur bei der ersten URL
+    # diese Behandlung deckt auch Personal Plus API Kunden ab, da dann nur noch eine URL aufgerufen wird, url2 wird dort ignoriert
     if api_key != 'kein' and forecastactual == 'ja':
         sqlall = FUNCTIONS.SQLall.sqlall()
         currentDayProduction = sqlall.getSQLcurrentDayProduction('PV_Daten.sqlite')
         url = url+'&actual=' +"{:.1f}".format(currentDayProduction)
-        url2 = url2+'&actual=' +"{:.1f}".format(currentDayProduction)
 
     try:
         try:

--- a/WeatherDataProvider2.py
+++ b/WeatherDataProvider2.py
@@ -33,6 +33,7 @@ def loadLatestWeatherData():
 
     # resolution auf 60 Minuten und damping an die URL anhängen:
     url = url+'?resolution=60&damping={}'.format(forecastdamping)
+    url2 = url2+'?resolution=60&damping={}'.format(forecastdamping)
 
     # actual nur wenn ein API key vorhanden ist
     if api_key != 'kein' and forecastactual == 'ja':

--- a/WeatherDataProvider2.py
+++ b/WeatherDataProvider2.py
@@ -9,12 +9,14 @@ def loadLatestWeatherData():
     forecastactual = basics.getVarConf('forecast.solar','forecastactual','str')
     forecastdamping = basics.getVarConf('forecast.solar','forecastdamping','str')
     api_pers_plus = basics.getVarConf('forecast.solar','api_pers_plus','str')
+    horizon = basics.getVarConf('forecast.solar','horizon','eval')
     lat = basics.getVarConf('forecast.solar','lat','eval')
     lon = basics.getVarConf('forecast.solar','lon','eval')
     dec = basics.getVarConf('forecast.solar','dec','eval')
     az = basics.getVarConf('forecast.solar','az','eval')
     kwp = basics.getVarConf('forecast.solar','kwp','eval')
     anzahl_strings = basics.getVarConf('pv.strings','anzahl','eval')
+    horizon2 = basics.getVarConf('forecast.solar2','horizon','eval')
     dec2 = basics.getVarConf('forecast.solar2','dec','eval')
     az2 = basics.getVarConf('forecast.solar2','az','eval')
     kwp2 = basics.getVarConf('forecast.solar2','kwp','eval')
@@ -31,9 +33,9 @@ def loadLatestWeatherData():
             url = url_anfang+'/estimate/{}/{}/{}/{}/{}/{}/{}/{}'.format(lat, lon, dec, az, kwp, dec2, az2, kwp2)
             anzahl_strings = 1
 
-    # resolution auf 60 Minuten und damping an die URL anhängen:
-    url = url+'?resolution=60&damping={}'.format(forecastdamping)
-    url2 = url2+'?resolution=60&damping={}'.format(forecastdamping)
+    # resolution auf 60 Minuten, horizon und damping an die URL anhängen:
+    url = url+'?resolution=60&horizon={}&damping={}'.format(horizon, forecastdamping)
+    url2 = url2+'?resolution=60&horizon={}&damping={}'.format(horizon2, forecastdamping)
 
     # actual nur wenn ein API key vorhanden ist
     if api_key != 'kein' and forecastactual == 'ja':

--- a/WeatherDataProvider2.py
+++ b/WeatherDataProvider2.py
@@ -6,6 +6,8 @@ import FUNCTIONS.SQLall
 
 def loadLatestWeatherData():
     api_key = basics.getVarConf('forecast.solar','api_key','str')
+    forecastactual = basics.getVarConf('forecast.solar','forecastactual','str')
+    forecastdamping = basics.getVarConf('forecast.solar','forecastdamping','str')
     api_pers_plus = basics.getVarConf('forecast.solar','api_pers_plus','str')
     lat = basics.getVarConf('forecast.solar','lat','eval')
     lon = basics.getVarConf('forecast.solar','lon','eval')
@@ -19,20 +21,21 @@ def loadLatestWeatherData():
 
     # Unterscheidung zwischen Free, Personal und Personal Plus
     url_anfang ='https://api.forecast.solar'
-    url = url_anfang+'/estimate/{}/{}/{}/{}/{}'.format(lat, lon, dec, az, kwp)
-    url2 = url_anfang+'/estimate/{}/{}/{}/{}/{}'.format(lat, lon, dec2, az2, kwp2)
+    url = url_anfang+'/estimate/{}/{}/{}/{}/{}?damping={}'.format(lat, lon, dec, az, kwp, forecastdamping)
+    url2 = url_anfang+'/estimate/{}/{}/{}/{}/{}?damping={}'.format(lat, lon, dec2, az2, kwp2, forecastdamping)
     if api_key != 'kein':
         url_anfang = 'https://api.forecast.solar/'+api_key
-        url = url_anfang+'/estimate/{}/{}/{}/{}/{}'.format(lat, lon, dec, az, kwp)
-        url2 = url_anfang+'/estimate/{}/{}/{}/{}/{}'.format(lat, lon, dec2, az2, kwp2)
+        url = url_anfang+'/estimate/{}/{}/{}/{}/{}?damping={}'.format(lat, lon, dec, az, kwp, forecastdamping)
+        url2 = url_anfang+'/estimate/{}/{}/{}/{}/{}?damping={}'.format(lat, lon, dec2, az2, kwp2, forecastdamping)
         if anzahl_strings == 2 and api_pers_plus == 'ja':
-            url = url_anfang+'/estimate/{}/{}/{}/{}/{}/{}/{}/{}'.format(lat, lon, dec, az, kwp, dec2, az2, kwp2)
+            url = url_anfang+'/estimate/{}/{}/{}/{}/{}/{}/{}/{}?damping={}'.format(lat, lon, dec, az, kwp, dec2, az2, kwp2, forecastdamping)
             anzahl_strings = 1
 
-    if api_pers_plus == 'ja' and anzahl_strings == 1:
+    if forecastactual == "ja":
         sqlall = FUNCTIONS.SQLall.sqlall()
         currentDayProduction = sqlall.getSQLcurrentDayProduction('PV_Daten.sqlite')
-        url = url+'?actual=' +"{:.1f}".format(currentDayProduction)
+        url = url+'&actual=' +"{:.1f}".format(currentDayProduction)
+        url2 = url2+'&actual=' +"{:.1f}".format(currentDayProduction)
 
     try:
         try:

--- a/WeatherDataProvider2.py
+++ b/WeatherDataProvider2.py
@@ -21,15 +21,18 @@ def loadLatestWeatherData():
 
     # Unterscheidung zwischen Free, Personal und Personal Plus
     url_anfang ='https://api.forecast.solar'
-    url = url_anfang+'/estimate/{}/{}/{}/{}/{}?damping={}'.format(lat, lon, dec, az, kwp, forecastdamping)
-    url2 = url_anfang+'/estimate/{}/{}/{}/{}/{}?damping={}'.format(lat, lon, dec2, az2, kwp2, forecastdamping)
+    url = url_anfang+'/estimate/{}/{}/{}/{}/{}'.format(lat, lon, dec, az, kwp)
+    url2 = url_anfang+'/estimate/{}/{}/{}/{}/{}'.format(lat, lon, dec2, az2, kwp2)
     if api_key != 'kein':
         url_anfang = 'https://api.forecast.solar/'+api_key
-        url = url_anfang+'/estimate/{}/{}/{}/{}/{}?damping={}'.format(lat, lon, dec, az, kwp, forecastdamping)
-        url2 = url_anfang+'/estimate/{}/{}/{}/{}/{}?damping={}'.format(lat, lon, dec2, az2, kwp2, forecastdamping)
+        url = url_anfang+'/estimate/{}/{}/{}/{}/{}'.format(lat, lon, dec, az, kwp)
+        url2 = url_anfang+'/estimate/{}/{}/{}/{}/{}'.format(lat, lon, dec2, az2, kwp2)
         if anzahl_strings == 2 and api_pers_plus == 'ja':
-            url = url_anfang+'/estimate/{}/{}/{}/{}/{}/{}/{}/{}?damping={}'.format(lat, lon, dec, az, kwp, dec2, az2, kwp2, forecastdamping)
+            url = url_anfang+'/estimate/{}/{}/{}/{}/{}/{}/{}/{}'.format(lat, lon, dec, az, kwp, dec2, az2, kwp2)
             anzahl_strings = 1
+
+    # resolution auf 60 Minuten und damping an die URL anhängen:
+    url = url+'?resolution=60&damping={}'.format(forecastdamping)
 
     # actual nur wenn ein API key vorhanden ist
     if api_key != 'kein' and forecastactual == 'ja':
@@ -82,9 +85,6 @@ def loadLatestWeatherData():
                 json_data1['result']['watts']=dict_watts
                 json_data1['result']['watt_hours']=dict_watt_hours
 
-        for key in list(json_data1['result']['watts'].keys()):
-            if ':15:00' in key or ':30:00' in key or ':45:00' in key:
-                del json_data1['result']['watts'][key]
         #print(json_data1, "\n")
         return(json_data1)
     except OSError:


### PR DESCRIPTION
forecast.solar API provides better forecast values for 'personal' subscribers and up if the actual accumulated PV production is submitted: https://doc.forecast.solar/actual

as the current version only checks for api_pers_plus to merge two strings into one API call i append the ?actual=xx.x to this very call if present
example:
WETTER URL: https://api.forecast.solar/apikey_123456/estimate/78.975/13.368/34/0/5.55/10/0/4.44?actual=20.5
forecast.solar OK: Prognosedaten vom 2025-04-25 21:08:56 gespeichert.