### PR TITLE
v0.31.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+**[0.31.2] – 2025-XX-XX**  
+
+**Änderung in der LadeStrg:**
+- Die Spalten zur Reservierung von PV-Leistungen können nicht mehr frei benannt werden.  
+  Die Variablen $Res_Feld1 und $Res_Feld2 wurden aus der `html/config.php` entfernt und sollten auch aus der `html/config_priv.php` entfernt werden.  
+- Die Spalten heißen nun `einmal` und `laufend`  
+  - Die Werte der Spalte einmal gelten nur für den Tag, bei dem sie eingetragen wurden, und fallen dann weg.  
+  - Die Werte der Spalte laufend werden jeden Tag wiederholt, bis sie geändert oder gelöscht werden.  
+
 **[0.31.1] – 2025-08-20**  
 
 FIX: Im `ForecastMgr` konnten Quellen nicht mehr vollständig gelöscht werden.

--- a/docs/WIKI/LadeStrg.html
+++ b/docs/WIKI/LadeStrg.html
@@ -20,6 +20,10 @@
 
 
 
+
+
+
+
           ForecastMgr</b></a></div>
     <!--HIERZURUECK-->
     <center> <font style="font-size: 24pt"><b><span style="background:
@@ -71,14 +75,23 @@
         Gültigkeitsstunden abgefragt, nach deren Ablauf wird wieder <b>Auto</b>
         angewendet.<br>
       </p>
-      <p>In der Prognosetabelle können in den Spalten <b>vier</b> und <b>fünf</b><br>
-        PV-Leistungen in KW zur Reservierung eingetragen werden. <br>
+      <p>In der Prognosetabelle können in den Spalten <b>einmal</b> und
+        <b>laufend</b><br>
+        PV-Leistungen in kW zur Reservierung eingetragen werden. <br>
+        Die Werte der Spalte <b>einmal</b> gelten nur für den Tag bei
+        dem sie eingetragen wurden, und fallen dann weg.<br>
+        &nbsp; Die Werte der Spalte <b>laufend</b> werden jeden Tag
+        wiederholt, bis sie geändert oder gelöscht werden.<br>
         <br>
         Die Leistungsreservierung wird dann bei der Ladungsplanung<br>
         des Hausakkus berücksichtigt (wenn Ladegrenze = AUTO).</p>
     </center>
     <hr width="100%" size="2">
     <h2 class="western" align="center"> <a name="weatherDataManager"></a>Prognoseberechnung
+
+
+
+
 
 
 

--- a/html/1_tab_LadeSteuerung.php
+++ b/html/1_tab_LadeSteuerung.php
@@ -174,8 +174,11 @@ if(file_exists("config_priv.php")){
 }
 include 'SQL_steuerfunctions.php';
 $EV_Reservierung = getSteuercodes('Reservierung');
+$PrstLadeStd = getPrstLadeStd();
 $Prognose = getPrognose();
 
+$Res_Feld1 = 'einmal';
+$Res_Feld2 = 'laufend';
 $DB_ManuelleSteuerung_wert = 0;
 $DB_Auto_selected = '';
 $DB_Slider_selected = '';
@@ -261,6 +264,14 @@ $Prognosewert_Sum = number_format($Prognosewert_Sum + $Prognosewert,1);
 $Rest_KW_Sum = number_format($Rest_KW_Sum + (float) $Rest_KW,1);
 $Res_Feld1_Watt_Sum = number_format($Res_Feld1_Watt_Sum + (float) $Res_Feld1_Watt,1);
 $Res_Feld2_Watt_Sum = number_format($Res_Feld2_Watt_Sum + (float) $Res_Feld2_Watt,1);
+// Stunde aus $date extrahieren
+$stunde = date('H:00:00', strtotime($date));
+$datum = date('Y-m-d', strtotime($date));
+$heute = date('Y-m-d');
+# Wenn  Res_Feld2 = 'laufend' gesetzt dann zuweisen
+if (isset($PrstLadeStd[$stunde]) and $datum == $heute) {
+    if ($PrstLadeStd[$stunde]['Res_Feld2'] !== '0') $EV_Reservierung[$date]['Res_Feld2'] = $PrstLadeStd[$stunde]['Res_Feld2'];
+}
 
 if (isset($EV_Reservierung[$date]['Res_Feld1'])){
     $Res_Feld1_wert = (float) $EV_Reservierung[$date]['Res_Feld1']/1000;

--- a/html/4_tab_config_ini.php
+++ b/html/4_tab_config_ini.php
@@ -90,7 +90,7 @@ td {font-size: 140%;
 
 <div class="version" align="center">
 <br><br>
-<b>  GEN24_Ladesteuerung Version: 0.31.1 </b>
+<b>  GEN24_Ladesteuerung Version: 0.31.2 </b>
 </div>
 <?php
 include "config.php";

--- a/html/SQL_steuerfunctions.php
+++ b/html/SQL_steuerfunctions.php
@@ -77,4 +77,38 @@ function getPrognose() {
     return ['result' => ['watts' => $watts]];
 }
 
+function getPrstLadeStd() {
+global $PythonDIR;
+$SQLfile = $PythonDIR.'/CONFIG/Prog_Steuerung.sqlite';
+$db = new SQLite3($SQLfile);
+$SQL = "
+        SELECT strftime('%H:00:00', Zeit) AS Stunde,
+            MIN(Res_Feld2) AS Res_Feld2
+        FROM steuercodes
+        WHERE Res_Feld2 != 0
+            AND Schluessel = 'Reservierung'
+            AND ID LIKE '1%'
+        GROUP BY strftime('%Y-%m-%d %H', Zeit)
+        ORDER BY Stunde;
+        ";
+
+
+        $results = $db->query($SQL);
+        $data = array();
+
+        // Fetch Associated Array
+        if($results != false){
+            while ($row = $results->fetchArray(SQLITE3_ASSOC))
+            {
+                $stunde = $row['Stunde'];
+                $data[$stunde] = array(
+                    'Res_Feld2' => $row['Res_Feld2']
+                );
+            }
+        }
+        
+$db->close();
+
+return $data;
+}
 ?>

--- a/html/config.php
+++ b/html/config.php
@@ -3,8 +3,6 @@ $PythonDIR = "..";
 $PV_Leistung_KWp = 11.4;
 $Faktor_PVLeistung_Prognose = 1.00;
 $Diagrammgrenze = 25000;
-$Res_Feld1 = "EV_1";
-$Res_Feld2 = "EV_2";
 $passwd_configedit = "0815";
 // Hier können die TABs konfiguriert werden (Name, Dateiname, Starttab, anzeigen ja/nein)
 $TAB_config = array (


### PR DESCRIPTION
**Änderung in der LadeStrg:**
- Die Spalten zur Reservierung von PV-Leistungen können nicht mehr frei benannt werden.
  Die Variablen $Res_Feld1 und $Res_Feld2 wurden aus der `html/config.php` entfernt und sollten auch aus der `html/config_priv.php` entfernt werden.
- Die Spalten heißen nun `einmal` und `laufend`
  - Die Werte der Spalte einmal gelten nur für den Tag, bei dem sie eingetragen wurden, und fallen dann weg.
  - Die Werte der Spalte laufend werden jeden Tag wiederholt, bis sie geändert oder gelöscht werden.

