### PR TITLE
v0.38.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 - FIX: Eintrag viertelstündlicher Werte aus DynamicPriceCheck.py mit führender Null wird in PHP7 nicht richtig ausgelesen.  
 - `Akku_MindestSOC = 5` in CONFIG/dynprice.ini eingefügt, damit kann ein höherer MIN-SOC als im GEN24 eingestellt werden, um mehr Reserve zu haben.   
 
+**NEU** Nachdem nun die Strompreise viertelstündlich kommen, wurde auch der Tageszeit abhängiger Preisanteil in Euro (z.B. Netzentgelte nach $14a BRD)  
+        auf viertelstündlich umgestellt. 
+        Anpassung auf Minutentakt in ´CONFIG/dynprice_priv.ini´ und ´CONFIG/dynprice_priv.ini´ an ´Tageszeit_Preisanteil´ nötig.  
+
 **[0.38.4] – 2025-09-28**  
 
 - FIX: Änderung der API `components/readable` wenn der Akku aus oder in Standby ist.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
-**[0.38.5] – 2025-XX-XX**  
+**[0.38.5] – 2025-10-06**  
 
 - FIX: Eintrag viertelstündlicher Werte aus DynamicPriceCheck.py mit führender Null wird in PHP7 nicht richtig ausgelesen.  
 - `Akku_MindestSOC = 5` in CONFIG/dynprice.ini eingefügt, damit kann ein höherer MIN-SOC als im GEN24 eingestellt werden, um mehr Reserve zu haben.   
+- Einige Anpassungen durch die Umstellung der Datenquellen auf viertelstündliche Strompreise.  
 
 **NEU** 
 Nachdem nun die Strompreise viertelstündlich kommen, wurde auch der Tageszeit abhängiger Preisanteil in Euro (z.B. Netzentgelte nach $14a BRD) auf viertelstündlich umgestellt.  
-Anpassung auf Minutentakt in `CONFIG/dynprice_priv.ini` und `CONFIG/dynprice_priv.ini` an `Tageszeit_Preisanteil` nötig.  
+- Anpassung auf Minutentakt in `CONFIG/dynprice_priv.ini` und `CONFIG/dynprice_priv.ini` an `Tageszeit_Preisanteil` nötig.  
 
 **[0.38.4] – 2025-09-28**  
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**[0.38.5] – 2025-XX-XX**  
+
+- FIX: Eintrag viertelstündlicher Werte aus DynamicPriceCheck.py mit führender Null wird in PHP7 nicht richtig ausgelesen.  
+
 **[0.38.4] – 2025-09-28**  
 
 - FIX: Änderung der API `components/readable` wenn der Akku aus oder in Standby ist.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 - FIX: Eintrag viertelstündlicher Werte aus DynamicPriceCheck.py mit führender Null wird in PHP7 nicht richtig ausgelesen.  
 - `Akku_MindestSOC = 5` in CONFIG/dynprice.ini eingefügt, damit kann ein höherer MIN-SOC als im GEN24 eingestellt werden, um mehr Reserve zu haben.   
 
-**NEU** Nachdem nun die Strompreise viertelstündlich kommen, wurde auch der Tageszeit abhängiger Preisanteil in Euro (z.B. Netzentgelte nach $14a BRD)  
-        auf viertelstündlich umgestellt. 
-        Anpassung auf Minutentakt in ´CONFIG/dynprice_priv.ini´ und ´CONFIG/dynprice_priv.ini´ an ´Tageszeit_Preisanteil´ nötig.  
+**NEU** 
+Nachdem nun die Strompreise viertelstündlich kommen, wurde auch der Tageszeit abhängiger Preisanteil in Euro (z.B. Netzentgelte nach $14a BRD) auf viertelstündlich umgestellt.  
+Anpassung auf Minutentakt in `CONFIG/dynprice_priv.ini` und `CONFIG/dynprice_priv.ini` an `Tageszeit_Preisanteil` nötig.  
 
 **[0.38.4] – 2025-09-28**  
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 **[0.38.5] – 2025-XX-XX**  
 
 - FIX: Eintrag viertelstündlicher Werte aus DynamicPriceCheck.py mit führender Null wird in PHP7 nicht richtig ausgelesen.  
+- `Akku_MindestSOC = 5` in CONFIG/dynprice.ini eingefügt, damit kann ein höherer MIN-SOC als im GEN24 eingestellt werden, um mehr Reserve zu haben.   
 
 **[0.38.4] – 2025-09-28**  
 

--- a/CONFIG/dynprice.ini
+++ b/CONFIG/dynprice.ini
@@ -37,11 +37,12 @@ netzlade_preisschwelle = 0.00
 ; smart_api (https://smard.api.bund.dev/)
 Preisquelle = energycharts
 LAND = DE-LU
-; Tageszeitabhängiger Preisanteil in Euro (z.B. Netzentgelte nach $14a)
-; Hier die Stundenbereiche mit den Nettopreisen in der Form {"Std":"Nettopreis", ...} angeben,
-; Std. muss mit "00" beginnen und immer zweistellig sein.
-; Beispiel: { "00":"0.027","09":"0.1105","16":"0.1937"}
-Tageszeit_Preisanteil = { "00":"0.000","12":"0.000"}
+; Tageszeit abhängiger Preisanteil in Euro (z.B. Netzentgelte nach $14a BRD)
+; Hier die Zeitbereiche mit den Nettopreisen in der Form {"Std:Min":"Nettopreis", ...} angeben,
+; Std. muss mit "00:00" beginnen und immer jeweils zweistellig sein.
+; Das Minutenintervall muss wie die Strompreise im 15-Minutentakt sein.
+; Beispiel: { "00:00":"0.027","09:30":"0.1105","16:15":"0.1937"}
+Tageszeit_Preisanteil = { "00:00":"0.000","12:30":"0.000"}
 ; Nettoaufschlag EURO/kWh
 Nettoaufschlag = 0.1528
 ; Prozentualer Aufschlag z.B. MwSt

--- a/CONFIG/dynprice.ini
+++ b/CONFIG/dynprice.ini
@@ -19,6 +19,8 @@ Daysback = 35
 charge_rate_kW = 4000
 ; Ladeverluste beim Laden und Abschreibungsverluste des Hausakkus
 Akku_Verlust_Prozent = 15
+; Hier kann ein MindestSOC des Akku definiert werden, wenn er höher als der am GEN24 eingestellte sein soll. 
+Akku_MindestSOC = 5
 ; Ladung anpassen durch Pufferfaktor, der auf den Verbrauch aus dem Lastprofil angewendet wird
 Lade_Verbrauchs_Faktor = 1.1
 ; Um den Wert Gewinnerwartung_kWh muss der Preis in EURO/kWh bei

--- a/CONFIG/dynprice.ini
+++ b/CONFIG/dynprice.ini
@@ -32,10 +32,11 @@ max_batt_dyn_ladung = 99
 netzlade_preisschwelle = 0.00
 
 ; Strompreisquellen
-; energycharts (https://api.energy-charts.info/)
-; ACHTUNG: smart_api liefert viertestündliche Strompreise, Aktuell nur zu Testzwecken verwenden
-; smart_api (https://smard.api.bund.dev/)
-Preisquelle = energycharts
+; energycharts (https://api.energy-charts.info/) => resolution immer quarterhour
+; smart_api (https://smard.api.bund.dev/) => resolution Auswahl möglich
+Preisquelle = smart_api
+; Zeitliche Auflösung, resolution: mögliche Werte hour quarterhour
+resolution = quarterhour
 LAND = DE-LU
 ; Tageszeit abhängiger Preisanteil in Euro (z.B. Netzentgelte nach $14a BRD)
 ; Hier die Zeitbereiche mit den Nettopreisen in der Form {"Std:Min":"Nettopreis", ...} angeben,

--- a/CONFIG/dynprice.ini
+++ b/CONFIG/dynprice.ini
@@ -32,11 +32,15 @@ max_batt_dyn_ladung = 99
 netzlade_preisschwelle = 0.00
 
 ; Strompreisquellen
-; energycharts (https://api.energy-charts.info/) => resolution immer quarterhour
-; smart_api (https://smard.api.bund.dev/) => resolution Auswahl möglich
-Preisquelle = smart_api
+; energycharts (https://api.energy-charts.info/) 
+; energycharts liefert viertelstündliche Preise, bei resolution = hour wird ein Mittelwert berechnet.
+; 
+; smart_api (https://smard.api.bund.dev/) (beta)
+; smart_api liefert aktuell bei resolution = quarterhour  nur viermal den stündlichen Wert.
+Preisquelle = energycharts
 ; Zeitliche Auflösung, resolution: mögliche Werte hour quarterhour
-resolution = quarterhour
+resolution = hour
+; Mögliche Ländercodes siehe jeweilige Internetseite der Preisquelle
 LAND = DE-LU
 ; Tageszeit abhängiger Preisanteil in Euro (z.B. Netzentgelte nach $14a BRD)
 ; Hier die Zeitbereiche mit den Nettopreisen in der Form {"Std:Min":"Nettopreis", ...} angeben,

--- a/DynamicPriceCheck.py
+++ b/DynamicPriceCheck.py
@@ -40,7 +40,7 @@ if __name__ == '__main__':
     # Lastprofil neu erzeugen, wenn es älter als LastprofilNeuTage
     PV_Database = 'PV_Daten.sqlite'
     if len(Lastprofil) > 0 and len(Lastprofil[0]) > 3:
-        if ((TimestampNow) - int(Lastprofil[0][3]) > LastprofilNeuTage * 86400):
+        if ((TimestampNow) - int(float(Lastprofil[0][3])) > LastprofilNeuTage * 86400):
             if(dyn_print_level >= 1): print("Erzeuge Lastprofil, da älter als ", LastprofilNeuTage, " Tage!")
             dynamic.makeLastprofil(PV_Database, Lastgrenze, Daysback*-1)
             # Lastprofil nochmal neu holen

--- a/DynamicPriceCheck.py
+++ b/DynamicPriceCheck.py
@@ -109,14 +109,15 @@ if(dyn_print_level >= 3):
 # Akku-Kapazität und aktuelle Parameter
 api = FUNCTIONS.GEN24_API.gen24api()
 API = api.get_API()
-# Wenn Batterie offline, battery_capacity_Wh = 5%
+# Wenn Batterie offline, battery_capacity_Wh = 5% => in GEN24_API.gen24api()
 battery_capacity_Wh = (API['BattganzeKapazWatt']) # Kapazität in Wh
 current_charge_Wh = battery_capacity_Wh - API['BattKapaWatt_akt'] # aktueller Ladestand in Wh
 
-# Mindest-Ladestand in Prozent vom GEN24 lesen
+# Mindest-Ladestand in Prozent vom GEN24 und aus der dynprice.ini lesen
 host_ip = basics.getVarConf('gen24','hostNameOrIp', 'str')
 user = basics.getVarConf('gen24','user', 'str')
 password = basics.getVarConf('gen24','password', 'str')
+Akku_MindestSOC = basics.getVarConf('dynprice','Akku_MindestSOC', 'eval')
 # Hier Hochkommas am Anfang und am Ende enternen
 password = password[1:-1]
 #  Klasse FroniusGEN24 initiieren
@@ -126,6 +127,8 @@ BAT_M0_SOC_MIN = batteries_array[3]
 HYB_BACKUP_RESERVED = batteries_array[2]
 minimum_batterylevel_Prozent = BAT_M0_SOC_MIN
 if HYB_BACKUP_RESERVED > BAT_M0_SOC_MIN: minimum_batterylevel_Prozent = HYB_BACKUP_RESERVED
+# größeren Wert als minimum_batterylevel_Prozent definieren
+minimum_batterylevel_Prozent = max(minimum_batterylevel_Prozent, Akku_MindestSOC)
 
 minimum_batterylevel_kWh =  int(battery_capacity_Wh / 100 * minimum_batterylevel_Prozent)     # Mindest-Ladestand in Wh
 Prozent5_batterylevel_kWh =  battery_capacity_Wh / 100 * 5     # 5_Prozent-Ladestand in Wh

--- a/FUNCTIONS/DynamicPrice.py
+++ b/FUNCTIONS/DynamicPrice.py
@@ -163,20 +163,25 @@ class dynamic:
 
         Tageszeit_Preisanteil = {}
 
-        for i in range(len(time_points)):
-            start_time, value = time_points[i]
-            if i + 1 < len(time_points):
-                end_time = time_points[i + 1][0]
-            else:
-                # Ende des Tages → 00:00 am Folgetag
-                end_time = datetime.strptime("00:00", "%H:%M") + timedelta(days=1)
+        # 15-Minuten Raster über den ganzen Tag
+        current = datetime.strptime("00:00", "%H:%M")
+        end_of_day = current + timedelta(days=1)
 
-            # Alle 15 Minuten vom Start bis kurz vor Ende
-            current = start_time
-            while current < end_time:
-                key = current.strftime("%H:%M")
-                Tageszeit_Preisanteil[key] = value
-                current += timedelta(minutes=15)
+        while current < end_of_day:
+            # letzten gültigen Eintrag finden
+            value = None
+            for t, v in time_points:
+                if t <= current:
+                    value = v
+                else:
+                    break
+
+            # falls noch kein gültiger Startwert (z.B. Raster < erstem Eintrag) → nimm letzten Wert vom Vortag
+            if value is None:
+                value = time_points[-1][1]
+
+            Tageszeit_Preisanteil[current.strftime("%H:%M")] = value
+            current += timedelta(minutes=15)
 
         # DEBUG
         if(self.dyn_print_level >= 4): print("++ Tageszeit_Preisanteil: ", Tageszeit_Preisanteil, "\n")

--- a/FUNCTIONS/DynamicPrice.py
+++ b/FUNCTIONS/DynamicPrice.py
@@ -239,8 +239,9 @@ class dynamic:
         Gebietsfilter = 4169 # für DE-LU 
         if(BZN == 'AT'): Gebietsfilter = 4170
 
-        #  viertestündliche Strompreise
-        url = "https://smard.api.proxy.bund.dev/app/chart_data/{}/{}/{}_{}_quarterhour_{}000.json".format(Gebietsfilter, BZN, Gebietsfilter, BZN, montag_timestamp)
+        #  stündliche oder viertestündliche Strompreise
+        resolution = basics.getVarConf('dynprice','resolution', 'str') 
+        url = "https://smard.api.proxy.bund.dev/app/chart_data/{}/{}/{}_{}_{}_{}000.json".format(Gebietsfilter, BZN, Gebietsfilter, BZN, resolution, montag_timestamp)
         timeout_sec = 30
         Push_Schreib_Ausgabe = ''
         

--- a/FUNCTIONS/DynamicPrice.py
+++ b/FUNCTIONS/DynamicPrice.py
@@ -629,11 +629,9 @@ class dynamic:
              morgen.strftime('%Y-%m-%d 23:59:59'))
         )
 
-        # auch in priceforecast Werte von heute und morgen loeschen
+        # in priceforecast alle Werte loeschen, wenn es länger nicht gelaufen ist...
         zeiger.execute(
-            "DELETE FROM priceforecast WHERE Zeitpunkt BETWEEN ? AND ?",
-            (heute.strftime('%Y-%m-%d 00:00:00'),
-             morgen.strftime('%Y-%m-%d 23:59:59'))
+            "DELETE FROM priceforecast"
         )
 
         # Daten einfügen oder aktualisieren

--- a/FUNCTIONS/PrognoseLadewert.py
+++ b/FUNCTIONS/PrognoseLadewert.py
@@ -287,6 +287,7 @@ class progladewert:
         DEBUG_Eig_opt ="\nDEBUG\nDEBUG <<<<<<<< Eigenverbrauchs-Optimierung  >>>>>>>>>>>>>"
         GrundlastNacht = basics.getVarConf('EigenverbOptimum','GrundlastNacht','eval')
         AkkuZielProz = basics.getVarConf('EigenverbOptimum','AkkuZielProz','eval')
+        MindBattLad = basics.getVarConf('Ladeberechnung','MindBattLad','eval')
         RundungEinspeisewert = basics.getVarConf('EigenverbOptimum','RundungEinspeisewert','eval')
         PrognoseGrenzeMorgen = basics.getVarConf('EigenverbOptimum','PrognoseGrenzeMorgen','eval')
         PrognoseMorgen_arr = self.getPrognoseMorgen(MaxEinspeisung)
@@ -328,7 +329,7 @@ class progladewert:
             # Die aktuelle Einspeisung nicht mehr verändern
             Eigen_Opt_Std_neu = Eigen_Opt_Std
             if Eigen_Opt_Std_neu <= RundungEinspeisewert:
-                if (PrognoseMorgen < PrognoseGrenzeMorgen / 2):
+                if ((PrognoseMorgen < PrognoseGrenzeMorgen / 2) or (BattStatusProz < MindBattLad * 0.85 )):
                     DEBUG_Eig_opt_tmp = "\nDEBUG ## >>> Bei PrognoseMorgen < PrognoseGrenzeMorgen / 2, keine Einspeisung während des Tages"
                     DEBUG_Eig_opt_tmp += "\nDEBUG ## >>> Prognose 24H+: " + str(PrognoseMorgen) + ", PrognoseGrenzeMorgen: " + str(PrognoseGrenzeMorgen) 
                     Eigen_Opt_Std_neu = 0

--- a/docs/WIKI/Inst_RaspPi.html
+++ b/docs/WIKI/Inst_RaspPi.html
@@ -124,7 +124,11 @@ sudo chmod +x /home/GEN24/start_PythonScript.sh
           die Daten aktuell hat, kann beim Ausführen zur vollen fünften
           Minute passieren, dass die Daten vom GEN24 noch nicht zur
           Verfügung stehen. Dadurch entstehen unschöne Zacken in der
-          Tagesgrafik.</p>
+          Tagesgrafik.<br>
+          Bei Verwendung der Dynamischen Strompreise zur
+          Lade-/Entladesteuerung alle fünf Minuten ausführen (1-56/5),
+          da die Strompreistaktung nun alle 15 Minuten erfolgt.<br>
+        </p>
       </li>
     </ul>
     <div class="snippet-clipboard-content notranslate position-relative
@@ -201,6 +205,7 @@ sudo apt install php php-sqlite3
 
 
 
+
         = 1</code> (Standard) in der CONFIG/default_priv.ini beim ersten
       Start von <code>start_PythonScript.sh</code> automatisch der
       einfache PHP-Webserver gestartet werden. Die Webseite ist dann auf
@@ -227,6 +232,7 @@ sudo apt install apache2
       <li>/etc/apache2/envvars <code>export APACHE_RUN_GROUP=www-data</code>
         nach <code>export APACHE_RUN_GROUP=pi</code> ändern.</li>
       <li>/etc/apache2/sites-enabled/000-default.conf <code>DocumentRoot
+
 
 
 

--- a/docs/WIKI/config.html
+++ b/docs/WIKI/config.html
@@ -382,9 +382,9 @@ button {
 <td><input type="text" name="Zeile[30][1]" value="energycharts" readonly></td></tr>
 <tr><td class="variablenname">LAND</td>
 <td><input type="text" name="Zeile[31][1]" value="DE-LU" readonly></td></tr>
-<tr class="comment"><td colspan="2">; Tageszeitabhängiger Preisanteil in Euro (z.B. Netzentgelte nach $14a)<br>; Hier die Stundenbereiche mit den Nettopreisen in der Form {&quot;Std&quot;:&quot;Nettopreis&quot;, ...} angeben,<br>; Std. muss mit &quot;00&quot; beginnen und immer zweistellig sein.<br>; Beispiel: { &quot;00&quot;:&quot;0.027&quot;,&quot;09&quot;:&quot;0.1105&quot;,&quot;16&quot;:&quot;0.1937&quot;} </td></tr>
+<tr class="comment"><td colspan="2">; Tageszeit abhängiger Preisanteil in Euro (z.B. Netzentgelte nach $14a BRD)<br>; Hier die Zeitbereiche mit den Nettopreisen in der Form {&quot;Std:Min&quot;:&quot;Nettopreis&quot;, ...} angeben,<br>; Std. muss mit &quot;00:00&quot; beginnen und immer jeweils zweistellig sein.<br>; Das Minutenintervall muss wie die Strompreise im 15-Minutentakt sein.<br>; Beispiel: { &quot;00:00&quot;:&quot;0.027&quot;,&quot;09:30&quot;:&quot;0.1105&quot;,&quot;16:15&quot;:&quot;0.1937&quot;} </td></tr>
 <tr><td class="variablenname">Tageszeit_Preisanteil</td>
-<td><input type="text" name="Zeile[33][1]" value="{ &quot;00&quot;:&quot;0.000&quot;,&quot;12&quot;:&quot;0.000&quot;}" readonly></td></tr>
+<td><input type="text" name="Zeile[33][1]" value="{ &quot;00:00&quot;:&quot;0.000&quot;,&quot;12:30&quot;:&quot;0.000&quot;}" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Nettoaufschlag EURO/kWh </td></tr>
 <tr><td class="variablenname">Nettoaufschlag</td>
 <td><input type="text" name="Zeile[35][1]" value="0.1528" readonly></td></tr>
@@ -392,6 +392,6 @@ button {
 <tr><td class="variablenname">MwSt</td>
 <td><input type="text" name="Zeile[37][1]" value="1.19" readonly></td></tr>
 <tr><td colspan="2"><input type="hidden" name="Zeile[38]" value='' ></td></tr>
-</table><div id="Hilfezu/CONFIG/dynpriceini"></div><br /><br /><hr />Hilfe erzeugt am 02.10.2025 durch make_config_help.php&nbsp;&nbsp;<a href="#top" style="font-size: 1.7rem; text-decoration: none;">⬆</a><br />
+</table><div id="Hilfezu/CONFIG/dynpriceini"></div><br /><br /><hr />Hilfe erzeugt am 03.10.2025 durch make_config_help.php&nbsp;&nbsp;<a href="#top" style="font-size: 1.7rem; text-decoration: none;">⬆</a><br />
 </body>
 </html>

--- a/docs/WIKI/config.html
+++ b/docs/WIKI/config.html
@@ -377,21 +377,25 @@ button {
 <tr><td class="variablenname">netzlade_preisschwelle</td>
 <td><input type="text" name="Zeile[27][1]" value="0.00" readonly></td></tr>
 <tr><td colspan="2"><input type="hidden" name="Zeile[28]" value='' ></td></tr>
-<tr class="comment"><td colspan="2">; Strompreisquellen<br>; energycharts (https://api.energy-charts.info/)<br>; ACHTUNG: smart_api liefert viertestündliche Strompreise, Aktuell nur zu Testzwecken verwenden<br>; smart_api (https://smard.api.bund.dev/) </td></tr>
+<tr class="comment"><td colspan="2">; Strompreisquellen<br>; energycharts (https://api.energy-charts.info/)<br>; energycharts liefert viertelstündliche Preise, bei resolution = hour wird ein Mittelwert berechnet.<br>;<br>; smart_api (https://smard.api.bund.dev/) (beta)<br>; smart_api liefert aktuell bei resolution = quarterhour  nur viermal den stündlichen Wert. </td></tr>
 <tr><td class="variablenname">Preisquelle</td>
 <td><input type="text" name="Zeile[30][1]" value="energycharts" readonly></td></tr>
+<tr class="comment"><td colspan="2">; Zeitliche Auflösung, resolution: mögliche Werte hour quarterhour </td></tr>
+<tr><td class="variablenname">resolution</td>
+<td><input type="text" name="Zeile[32][1]" value="hour" readonly></td></tr>
+<tr class="comment"><td colspan="2">; Mögliche Ländercodes siehe jeweilige Internetseite der Preisquelle </td></tr>
 <tr><td class="variablenname">LAND</td>
-<td><input type="text" name="Zeile[31][1]" value="DE-LU" readonly></td></tr>
+<td><input type="text" name="Zeile[34][1]" value="DE-LU" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Tageszeit abhängiger Preisanteil in Euro (z.B. Netzentgelte nach $14a BRD)<br>; Hier die Zeitbereiche mit den Nettopreisen in der Form {&quot;Std:Min&quot;:&quot;Nettopreis&quot;, ...} angeben,<br>; Std. muss mit &quot;00:00&quot; beginnen und immer jeweils zweistellig sein.<br>; Das Minutenintervall muss wie die Strompreise im 15-Minutentakt sein.<br>; Beispiel: { &quot;00:00&quot;:&quot;0.027&quot;,&quot;09:30&quot;:&quot;0.1105&quot;,&quot;16:15&quot;:&quot;0.1937&quot;} </td></tr>
 <tr><td class="variablenname">Tageszeit_Preisanteil</td>
-<td><input type="text" name="Zeile[33][1]" value="{ &quot;00:00&quot;:&quot;0.000&quot;,&quot;12:30&quot;:&quot;0.000&quot;}" readonly></td></tr>
+<td><input type="text" name="Zeile[36][1]" value="{ &quot;00:00&quot;:&quot;0.000&quot;,&quot;12:30&quot;:&quot;0.000&quot;}" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Nettoaufschlag EURO/kWh </td></tr>
 <tr><td class="variablenname">Nettoaufschlag</td>
-<td><input type="text" name="Zeile[35][1]" value="0.1528" readonly></td></tr>
+<td><input type="text" name="Zeile[38][1]" value="0.1528" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Prozentualer Aufschlag z.B. MwSt </td></tr>
 <tr><td class="variablenname">MwSt</td>
-<td><input type="text" name="Zeile[37][1]" value="1.19" readonly></td></tr>
-<tr><td colspan="2"><input type="hidden" name="Zeile[38]" value='' ></td></tr>
-</table><div id="Hilfezu/CONFIG/dynpriceini"></div><br /><br /><hr />Hilfe erzeugt am 03.10.2025 durch make_config_help.php&nbsp;&nbsp;<a href="#top" style="font-size: 1.7rem; text-decoration: none;">⬆</a><br />
+<td><input type="text" name="Zeile[40][1]" value="1.19" readonly></td></tr>
+<tr><td colspan="2"><input type="hidden" name="Zeile[41]" value='' ></td></tr>
+</table><div id="Hilfezu/CONFIG/dynpriceini"></div><br /><br /><hr />Hilfe erzeugt am 05.10.2025 durch make_config_help.php&nbsp;&nbsp;<a href="#top" style="font-size: 1.7rem; text-decoration: none;">⬆</a><br />
 </body>
 </html>

--- a/docs/WIKI/config.html
+++ b/docs/WIKI/config.html
@@ -361,34 +361,37 @@ button {
 <tr class="comment"><td colspan="2">; Ladeverluste beim Laden und Abschreibungsverluste des Hausakkus </td></tr>
 <tr><td class="variablenname">Akku_Verlust_Prozent</td>
 <td><input type="text" name="Zeile[17][1]" value="15" readonly></td></tr>
+<tr class="comment"><td colspan="2">; Hier kann ein MindestSOC des Akku definiert werden, wenn er höher als der am GEN24 eingestellte sein soll. </td></tr>
+<tr><td class="variablenname">Akku_MindestSOC</td>
+<td><input type="text" name="Zeile[19][1]" value="5" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Ladung anpassen durch Pufferfaktor, der auf den Verbrauch aus dem Lastprofil angewendet wird </td></tr>
 <tr><td class="variablenname">Lade_Verbrauchs_Faktor</td>
-<td><input type="text" name="Zeile[19][1]" value="1.1" readonly></td></tr>
+<td><input type="text" name="Zeile[21][1]" value="1.1" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Um den Wert Gewinnerwartung_kWh muss der Preis in EURO/kWh bei<br>; Speicherung in den Akku nach Abzug von Akku_Verlust_Prozent mindestens niedriger sein. </td></tr>
 <tr><td class="variablenname">Gewinnerwartung_kW</td>
-<td><input type="text" name="Zeile[21][1]" value="0.05" readonly></td></tr>
+<td><input type="text" name="Zeile[23][1]" value="0.05" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Bis zu wieviel Prozent darf der Akku aus dem Netz geladen werden </td></tr>
 <tr><td class="variablenname">max_batt_dyn_ladung</td>
-<td><input type="text" name="Zeile[23][1]" value="99" readonly></td></tr>
+<td><input type="text" name="Zeile[25][1]" value="99" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Bruttopreis, in EURO unter dem der Akku immer zwangsgeladen wird (kann auch Minuswert sein) </td></tr>
 <tr><td class="variablenname">netzlade_preisschwelle</td>
-<td><input type="text" name="Zeile[25][1]" value="0.00" readonly></td></tr>
-<tr><td colspan="2"><input type="hidden" name="Zeile[26]" value='' ></td></tr>
+<td><input type="text" name="Zeile[27][1]" value="0.00" readonly></td></tr>
+<tr><td colspan="2"><input type="hidden" name="Zeile[28]" value='' ></td></tr>
 <tr class="comment"><td colspan="2">; Strompreisquellen<br>; energycharts (https://api.energy-charts.info/)<br>; ACHTUNG: smart_api liefert viertestündliche Strompreise, Aktuell nur zu Testzwecken verwenden<br>; smart_api (https://smard.api.bund.dev/) </td></tr>
 <tr><td class="variablenname">Preisquelle</td>
-<td><input type="text" name="Zeile[28][1]" value="energycharts" readonly></td></tr>
+<td><input type="text" name="Zeile[30][1]" value="energycharts" readonly></td></tr>
 <tr><td class="variablenname">LAND</td>
-<td><input type="text" name="Zeile[29][1]" value="DE-LU" readonly></td></tr>
+<td><input type="text" name="Zeile[31][1]" value="DE-LU" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Tageszeitabhängiger Preisanteil in Euro (z.B. Netzentgelte nach $14a)<br>; Hier die Stundenbereiche mit den Nettopreisen in der Form {&quot;Std&quot;:&quot;Nettopreis&quot;, ...} angeben,<br>; Std. muss mit &quot;00&quot; beginnen und immer zweistellig sein.<br>; Beispiel: { &quot;00&quot;:&quot;0.027&quot;,&quot;09&quot;:&quot;0.1105&quot;,&quot;16&quot;:&quot;0.1937&quot;} </td></tr>
 <tr><td class="variablenname">Tageszeit_Preisanteil</td>
-<td><input type="text" name="Zeile[31][1]" value="{ &quot;00&quot;:&quot;0.000&quot;,&quot;12&quot;:&quot;0.000&quot;}" readonly></td></tr>
+<td><input type="text" name="Zeile[33][1]" value="{ &quot;00&quot;:&quot;0.000&quot;,&quot;12&quot;:&quot;0.000&quot;}" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Nettoaufschlag EURO/kWh </td></tr>
 <tr><td class="variablenname">Nettoaufschlag</td>
-<td><input type="text" name="Zeile[33][1]" value="0.1528" readonly></td></tr>
+<td><input type="text" name="Zeile[35][1]" value="0.1528" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Prozentualer Aufschlag z.B. MwSt </td></tr>
 <tr><td class="variablenname">MwSt</td>
-<td><input type="text" name="Zeile[35][1]" value="1.19" readonly></td></tr>
-<tr><td colspan="2"><input type="hidden" name="Zeile[36]" value='' ></td></tr>
-</table><div id="Hilfezu/CONFIG/dynpriceini"></div><br /><br /><hr />Hilfe erzeugt am 23.09.2025 durch make_config_help.php&nbsp;&nbsp;<a href="#top" style="font-size: 1.7rem; text-decoration: none;">⬆</a><br />
+<td><input type="text" name="Zeile[37][1]" value="1.19" readonly></td></tr>
+<tr><td colspan="2"><input type="hidden" name="Zeile[38]" value='' ></td></tr>
+</table><div id="Hilfezu/CONFIG/dynpriceini"></div><br /><br /><hr />Hilfe erzeugt am 02.10.2025 durch make_config_help.php&nbsp;&nbsp;<a href="#top" style="font-size: 1.7rem; text-decoration: none;">⬆</a><br />
 </body>
 </html>

--- a/docs/WIKI/docker.html
+++ b/docs/WIKI/docker.html
@@ -16,8 +16,11 @@
                 <meta http-equiv="content-type" content="text/html;
                   charset=UTF-8">
                 Infos zur Docker Nutzung</h1>
-              <h3 tabindex="-1" class="heading-element" dir="auto">-
-                Beispieldatei für Docker-compose siehe
+              <h3 tabindex="-1" class="heading-element" dir="auto"></h3>
+              <h2>Repository wiggal/gen24_ladesteuerung auf
+                https://hub.docker.com/</h2>
+              <h3 tabindex="-1" class="heading-element" dir="auto"><br>
+                - Beispieldatei für Docker-compose siehe
                 DOCKER/docker-compose.yml<br>
                 - Beispieldatei für Dockerbuilt siehe DOCKER/Dockerfile</h3>
               <p><br>

--- a/html/2_tab_EntladeSteuerung.php
+++ b/html/2_tab_EntladeSteuerung.php
@@ -214,7 +214,7 @@ if (isset($Akku_EntLadung[$date]['Res_Feld2']) and $Akku_EntLadung[$date]['Res_F
         $ergebnisse = [];
         foreach ($teile as $wert) {
             if($wert == 0){
-                $ergebnis = $wert;
+                $ergebnis = 0;
             }else{
                 $ergebnis = $wert/1000;
                 # Immer mindestens eine Nachkommastelle, auch wenn Null
@@ -225,7 +225,8 @@ if (isset($Akku_EntLadung[$date]['Res_Feld2']) and $Akku_EntLadung[$date]['Res_F
             $ergebnisse[] = $ergebnis;
         }
         $Res_Feld2_Watt = implode(";", $ergebnisse);
-        if($Res_Feld2_Watt == 0) $Res_Feld2_Watt = "";
+        # damit es sowohl in php7 alsuch in php8 funktioniert
+        if(is_numeric($Res_Feld2_Watt) && (float)$Res_Feld2_Watt == 0)$Res_Feld2_Watt = "";
 }
 
 if (isset($Akku_EntLadung[$date]['Options']) and $Akku_EntLadung[$date]['Options'] <> ""){

--- a/html/4_tab_config_ini.php
+++ b/html/4_tab_config_ini.php
@@ -90,7 +90,7 @@ td {font-size: 140%;
 
 <div class="version" align="center">
 <br><br>
-<b>  GEN24_Ladesteuerung Version: 0.38.4 </b>
+<b>  GEN24_Ladesteuerung Version: 0.38.5 </b>
 </div>
 <?php
 include "config.php";

--- a/html/7_funktion_Diagram.php
+++ b/html/7_funktion_Diagram.php
@@ -229,8 +229,8 @@ SELECT
     sp.Boersenpreis * 100 AS Boersenpreis,
     sp.Bruttopreis * 100 AS Bruttopreis,
 	pfc.PV_Prognose,
-	pfc.PrognNetzverbrauch,
-	pfc.PrognNetzladen,
+	pfc.PrognNetzverbrauch /60 * '".$PreisSector."' AS PrognNetzverbrauch,
+	pfc.PrognNetzladen /60 * '".$PreisSector."' AS PrognNetzladen,
 	pfc.PrognBattStatus
 FROM strompreise AS sp
 LEFT JOIN Alle_PVDaten AS pv

--- a/html/8_tab_Diagram.php
+++ b/html/8_tab_Diagram.php
@@ -61,6 +61,15 @@ if (!file_exists($SQLite_file)) {
     echo "</body></html>";
     exit();
 }
+# Datenbankverbindung herstellen
+$db = new SQLite3($SQLite_file);
+// Abfrage der internen sqlite_master Tabelle
+$result = $db->querySingle("SELECT name FROM sqlite_master WHERE type='table' AND name='pv_daten'");
+if (!$result) {
+    echo "SQLitetabelle pv_daten existiert nicht, keine Grafik verfügbar!<br>";
+    echo "Die Tabelle wird durch das Logging von http_SymoGen24Controller2.py erzeugt!";
+    exit();
+}
 
 # Variablendefinitionen
 $labels = '';
@@ -100,8 +109,6 @@ switch ($Zeitraum) {
     case 'jahre': $groupSTR = '%Y'; break;
 }
 
-# Datenbankverbindung herstellen
-$db = new SQLite3($SQLite_file);
 $DBersterTag = $GLOBALS['db']->querySingle('SELECT MIN(Zeitpunkt) from pv_daten');
 
 #$Footer_groupSTR = str_replace(" ","\T",$groupSTR);


### PR DESCRIPTION
- FIX: Eintrag viertelstündlicher Werte aus DynamicPriceCheck.py mit führender Null wird in PHP7 nicht richtig ausgelesen.  
- `Akku_MindestSOC = 5` in CONFIG/dynprice.ini eingefügt, damit kann ein höherer MIN-SOC als im GEN24 eingestellt werden, um mehr Reserve zu haben.   

**NEU** 
Nachdem nun die Strompreise viertelstündlich kommen, wurde auch der Tageszeit abhängiger Preisanteil in Euro (z.B. Netzentgelte nach $14a BRD) auf viertelstündlich umgestellt.
Anpassung auf Minutentakt in `CONFIG/dynprice_priv.ini` und `CONFIG/dynprice_priv.ini` an `Tageszeit_Preisanteil` nötig.


