### PR TITLE
v0.38.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**[0.38.6] – 2025-XX-XX**  
+
+- https://smard.api.bund.dev/ liefert nun auch viertelstündliche Strompreise.  
+
 **[0.38.5] – 2025-10-06**  
 
 - FIX: Eintrag viertelstündlicher Werte aus DynamicPriceCheck.py mit führender Null wird in PHP7 nicht richtig ausgelesen.  

--- a/CONFIG/dynprice.ini
+++ b/CONFIG/dynprice.ini
@@ -35,8 +35,8 @@ netzlade_preisschwelle = 0.00
 ; energycharts (https://api.energy-charts.info/) 
 ; energycharts liefert viertelstündliche Preise, bei resolution = hour wird ein Mittelwert berechnet.
 ; 
-; smart_api (https://smard.api.bund.dev/) (beta)
-; smart_api liefert aktuell bei resolution = quarterhour  nur viermal den stündlichen Wert.
+; smart_api (https://smard.api.bund.dev/)
+; smart_api liefert  hour und quarterhour Preise, je nach resolution.
 Preisquelle = energycharts
 ; Zeitliche Auflösung, resolution: mögliche Werte hour quarterhour
 resolution = hour

--- a/FUNCTIONS/DynamicPrice.py
+++ b/FUNCTIONS/DynamicPrice.py
@@ -183,8 +183,7 @@ class dynamic:
             Tageszeit_Preisanteil[current.strftime("%H:%M")] = value
             current += timedelta(minutes=15)
 
-        # DEBUG
-        if(self.dyn_print_level >= 4): print("++ Tageszeit_Preisanteil: ", Tageszeit_Preisanteil, "\n")
+        if(self.dyn_print_level >= 3): print("++ Tageszeit_Preisanteil: ", Tageszeit_Preisanteil, "\n") #DEBUG
 
         try:
             # viertelstündliche Netzentgelte addieren
@@ -236,6 +235,12 @@ class dynamic:
         #  stündliche oder viertestündliche Strompreise
         resolution = basics.getVarConf('dynprice','resolution', 'str') 
         url = "https://smard.api.proxy.bund.dev/app/chart_data/{}/{}/{}_{}_{}_{}000.json".format(Gebietsfilter, BZN, Gebietsfilter, BZN, resolution, montag_timestamp)
+
+        #DEBUG
+        if(self.dyn_print_level >= 2): 
+            print("++ ", url)
+            print("++  BZN = ", BZN, "; Gebietsfilter = ", Gebietsfilter, "; resolution = ", resolution, "\n")
+
         timeout_sec = 30
         Push_Schreib_Ausgabe = ''
         
@@ -316,6 +321,12 @@ class dynamic:
         # API-URL mit Parameter
         resolution = basics.getVarConf('dynprice','resolution', 'str') 
         url = "https://api.energy-charts.info/price?bzn={}&start={}&end={}".format(BZN, start_time, end_time)
+
+        #DEBUG
+        if(self.dyn_print_level >= 2): 
+            print("++ ", url)
+            print("++  BZN = ", BZN, "; resolution = ", resolution, "\n")
+
         timeout_sec = 30
         Push_Schreib_Ausgabe = ''
         

--- a/docs/WIKI/config.html
+++ b/docs/WIKI/config.html
@@ -377,7 +377,7 @@ button {
 <tr><td class="variablenname">netzlade_preisschwelle</td>
 <td><input type="text" name="Zeile[27][1]" value="0.00" readonly></td></tr>
 <tr><td colspan="2"><input type="hidden" name="Zeile[28]" value='' ></td></tr>
-<tr class="comment"><td colspan="2">; Strompreisquellen<br>; energycharts (https://api.energy-charts.info/)<br>; energycharts liefert viertelstündliche Preise, bei resolution = hour wird ein Mittelwert berechnet.<br>;<br>; smart_api (https://smard.api.bund.dev/) (beta)<br>; smart_api liefert aktuell bei resolution = quarterhour  nur viermal den stündlichen Wert. </td></tr>
+<tr class="comment"><td colspan="2">; Strompreisquellen<br>; energycharts (https://api.energy-charts.info/)<br>; energycharts liefert viertelstündliche Preise, bei resolution = hour wird ein Mittelwert berechnet.<br>;<br>; smart_api (https://smard.api.bund.dev/)<br>; smart_api liefert  hour und quarterhour Preise, je nach resolution. </td></tr>
 <tr><td class="variablenname">Preisquelle</td>
 <td><input type="text" name="Zeile[30][1]" value="energycharts" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Zeitliche Auflösung, resolution: mögliche Werte hour quarterhour </td></tr>
@@ -396,6 +396,6 @@ button {
 <tr><td class="variablenname">MwSt</td>
 <td><input type="text" name="Zeile[40][1]" value="1.19" readonly></td></tr>
 <tr><td colspan="2"><input type="hidden" name="Zeile[41]" value='' ></td></tr>
-</table><div id="Hilfezu/CONFIG/dynpriceini"></div><br /><br /><hr />Hilfe erzeugt am 05.10.2025 durch make_config_help.php&nbsp;&nbsp;<a href="#top" style="font-size: 1.7rem; text-decoration: none;">⬆</a><br />
+</table><div id="Hilfezu/CONFIG/dynpriceini"></div><br /><br /><hr />Hilfe erzeugt am 08.10.2025 durch make_config_help.php&nbsp;&nbsp;<a href="#top" style="font-size: 1.7rem; text-decoration: none;">⬆</a><br />
 </body>
 </html>

--- a/html/4_tab_config_ini.php
+++ b/html/4_tab_config_ini.php
@@ -90,7 +90,7 @@ td {font-size: 140%;
 
 <div class="version" align="center">
 <br><br>
-<b>  GEN24_Ladesteuerung Version: 0.38.5 </b>
+<b>  GEN24_Ladesteuerung Version: 0.38.6 </b>
 </div>
 <?php
 include "config.php";


### PR DESCRIPTION
- https://smard.api.bund.dev/ liefert nun auch viertelstündliche Strompreise.  
