### PR TITLE
v0.41.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 **[0.41.7] – 2026-XX-XX**  
-- Akkuschonung: Nun kann der Ladewert auch über diie höchste Zellspannung gesteuert werden.  
+- Akkuschonung: Nun kann der Ladewert auch über die höchste Zellspannung gesteuert werden.  
   **Änderung in CONFIG/default.ini** im Block `[inverter]` wurde hierzu die Variable `akkuIP` eingefügt, in `priv.ini` nachziehen.  
   **Änderung in CONFIG/charge.ini** im Block `[Ladeberechnung]` wurde hierzu die Variable `Zellspannungs_Werte` eingefügt, in `priv.ini` nachziehen.  i
        Wird Akkuschonung = 2 gesetzt, wird die höchste Zellspannung zur Ladeleistungsreduktion verwendet.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+**[0.41.7] – 2026-XX-XX**  
+- Akkuschonung: Nun kann der Ladewert auch über diie höchste Zellspannung gesteuert werden.  
+  **Änderung in CONFIG/default.ini** im Block `[inverter]` wurde hierzu die Variable `akkuIP` eingefügt, in `priv.ini` nachziehen.  
+  **Änderung in CONFIG/charge.ini** im Block `[Ladeberechnung]` wurde hierzu die Variable `Zellspannungs_Werte` eingefügt, in `priv.ini` nachziehen.  i
+       Wird Akkuschonung = 2 gesetzt, wird die höchste Zellspannung zur Ladeleistungsreduktion verwendet.  
+
 **[0.41.6] – 2026-03-29**  
 
 - Push-Meldungen können nun auch bei Hardwareausfällen von PV-Komponenten gesendet werden.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-**[0.41.7] – 2026-XX-XX**  
+**[0.41.7] – 2026-04-06**  
 - Akkuschonung: Nun kann der Ladewert auch über die höchste Zellspannung gesteuert werden.  
   **Änderung in CONFIG/default.ini** im Block `[inverter]` wurde hierzu die Variable `akkuIP` eingefügt, in `priv.ini` nachziehen.  
   **Änderung in CONFIG/charge.ini** im Block `[Ladeberechnung]` wurde hierzu die Variable `Zellspannungs_Werte` eingefügt, in `priv.ini` nachziehen.  i

--- a/CONFIG/charge.ini
+++ b/CONFIG/charge.ini
@@ -46,14 +46,18 @@ LadungAus = 0
 ; Wenn größter Prognosewert je Stunde ist kleiner als GrenzwertGroestePrognose volle Ladung (= MaxLadung)
 GrenzwertGroestePrognose = 2000
 
-; Akkuschonung (0=aus, 1=ein)
-; Wenn Akkuschonung ein, wird BattVollUm um eine Stunde vor verlegt, da am Schluss nicht mehr so stark geladen wird.
+; Akkuschonung (0=aus, 1=ein, 2=ein+Zellspannungs_Werte)
+; Wenn Akkuschonung ein (1 oder 2), wird BattVollUm um die berechnete Verzögerung vorverlegt, da am Schluss nicht mehr so stark geladen wird.
 ; ACHTUNG: Eine Überschreitung der Einspeisegrenze bzw. AC-Leistung des WR setzt die Akkuschonung aus!
 Akkuschonung = 1
 ; Akkuschonung_Werte = {"Ladestand%" : "LadewertC", ...}
 ; Akkuschonung_Ladewert = ((Akkukapazität * SOH / 100) * LadewertC), aufgerundet auf ganze 10 Watt.
 ; Heißt, der Akkuzustand wird hier wie auch bei anderen Berechnungen angehalten.
 Akkuschonung_Werte = {"80": "0.2", "90": "0.1", "95": "0.05"}
+; Akkuschonung = 2: Liegt die maximale Zellspannung der Akkuzellen über Zellspannung_ein wird zwingend der Ladewert LadewertC gesetzt,
+; unter Zellspannung_aus wird wieder der anderweitig berechnete Ladewert angehalten.
+; Zellspannungs_Werte = Zellspannung_ein,LadewertC,Zellspannung_aus
+Zellspannungs_Werte = 3.42,0.03,3.38
 ; bei Prognosemorgen über diesem Wert in kW, wird die Akkuladung auf X% begrenzt, 
 ; wenn nicht manuelle Strg ohne Akkuschonung ausgewählt ist.
 ; X ist der erste Wert aus dem String Akkuschonung_Werte

--- a/CONFIG/charge.ini
+++ b/CONFIG/charge.ini
@@ -48,16 +48,16 @@ GrenzwertGroestePrognose = 2000
 
 ; Akkuschonung (0=aus, 1=ein, 2=ein+Zellspannungs_Werte)
 ; Wenn Akkuschonung ein (1 oder 2), wird BattVollUm um die berechnete Verzögerung vorverlegt, da am Schluss nicht mehr so stark geladen wird.
-; ACHTUNG: Eine Überschreitung der Einspeisegrenze bzw. AC-Leistung des WR setzt die Akkuschonung aus!
+; ACHTUNG: Bei Akkuschonung = 2, akkuIP in default_priv.ini richtig konfigurieren
 Akkuschonung = 1
 ; Akkuschonung_Werte = {"Ladestand%" : "LadewertC", ...}
 ; Akkuschonung_Ladewert = ((Akkukapazität * SOH / 100) * LadewertC), aufgerundet auf ganze 10 Watt.
 ; Heißt, der Akkuzustand wird hier wie auch bei anderen Berechnungen angehalten.
-Akkuschonung_Werte = {"80": "0.2", "90": "0.1", "95": "0.05"}
+Akkuschonung_Werte = {"80": "0.2", "90": "0.1", "96": "0.02"}
 ; Akkuschonung = 2: Liegt die maximale Zellspannung der Akkuzellen über Zellspannung_ein wird zwingend der Ladewert LadewertC gesetzt,
 ; unter Zellspannung_aus wird wieder der anderweitig berechnete Ladewert angehalten.
 ; Zellspannungs_Werte = Zellspannung_ein,LadewertC,Zellspannung_aus
-Zellspannungs_Werte = 3.42,0.03,3.38
+Zellspannungs_Werte = 3.40,0.03,3.37
 ; bei Prognosemorgen über diesem Wert in kW, wird die Akkuladung auf X% begrenzt, 
 ; wenn nicht manuelle Strg ohne Akkuschonung ausgewählt ist.
 ; X ist der erste Wert aus dem String Akkuschonung_Werte

--- a/CONFIG/default.ini
+++ b/CONFIG/default.ini
@@ -24,6 +24,10 @@ user = customer
 ; Das Kennwort muss in einfache Hochkommas gesetzt werden, wegen evtl. Sonderzeichen
 ; sollte das Kennwort ein % enthalten bitte zwei %% eintragen.
 password = 'XXXXXXXX'
+; hier IP des BYD_Akku oder bei Fronius-Reserva reserva eintragen
+; Um den Zugriff auf den BYD_Akku zu ermöglichen, muss ein Routing zu 192.168.16.254
+; entweder am Rechner oder am Router eingetragen sein.
+akkuIP = 192.168.178.222
 ; Akkukapazität in Wh, wird benötigt, wenn Akku offline ist!!
 battery_capacity_Wh = 11000
 
@@ -40,7 +44,7 @@ log_level = 3
 ; Push_Message_EIN (1=EIN/0=AUS)
 ; Die Adresse des über die App erstellten Themennamen eintragen.
 Push_Message_EIN = 0
-; Wenn ERROR_Push_Message_EIN = 1, werden Pushmessages bei Harwareausfall versendet.
+; Wenn ERROR_Push_Message_EIN = 1, werden Pushmessages bei Hardwareausfall versendet.
 ; z.B. Smartmeter, Akku oder Wechselrichter ist nicht erreichbar
 ERROR_Push_Message_EIN = 1
 Push_Message_Url = https://ntfy.sh/XXXXXXXXX

--- a/EnergyController.py
+++ b/EnergyController.py
@@ -209,6 +209,9 @@ if __name__ == '__main__':
                     ManuelleSteuerung = int(reservierungdata_tmp['ManuelleSteuerung']['Res_Feld1'])
                     # Akkuschonung aus PV-Planung ermitteln
                     ManuelleStrg_Akkuschon = int(reservierungdata_tmp['ManuelleSteuerung']['Res_Feld2'])
+                    # Wenn Akkuschonung in PV-Planung gewählt, und Akkuschonung == 2 (Zellspannung berücksichtigen) ManuelleStrg_Akkuschon =2
+                    if ManuelleStrg_Akkuschon == 1 and Akkuschonung == 2:
+                        ManuelleStrg_Akkuschon = 2
                     # Prüfen, ob Einträge schon abgelaufen
                     try: 
                         Ablaufdatum = int(reservierungdata_tmp['ManuelleSteuerung']['Options'])
@@ -279,7 +282,8 @@ if __name__ == '__main__':
                                 WRSchreibGrenze_nachUnten, # Übergabe der aktuellen Werte
                                 DEBUG_Ausgabe, 
                                 LadewertGrund,
-                                WR_schreiben
+                                WR_schreiben,
+                                API['maxvolt']
                         )
 
                     # Wenn die aktuellePVProduktion < 50 Watt ist, nicht schreiben, 

--- a/EnergyController.py
+++ b/EnergyController.py
@@ -315,7 +315,7 @@ if __name__ == '__main__':
                             print(f"aktuelleBatteriePower/Watt:  {aktuelleBatteriePower}")
                             print(f"GesamtverbrauchHaus/Watt:    {GesamtverbrauchHaus}")
                             print(f"aktuelleBattKapazität/Watt:  {BattKapaWatt_akt}")
-                            print(f"Batteriestatus in Prozent:   {BattStatusProz}%")
+                            print(f"Batteriestatus (MaxVolt):    {BattStatusProz}%({API['maxvolt']}V)")
                             print(f"LadewertGrund:               {LadewertGrund}")
                             print(f"Bisheriger Ladewert/Watt:    {alterLadewert}")
                             print(f"Neuer Ladewert/Watt({BatSparFaktor: .1f}):   {aktuellerLadewert}")

--- a/FUNCTIONS/PrognoseLadewert.py
+++ b/FUNCTIONS/PrognoseLadewert.py
@@ -396,7 +396,7 @@ class progladewert:
                                    alterLadewert, aktuellerLadewert, ManuelleStrg_Akkuschon, aktuellePVProduktion,
                                    SOC_Proz_Grenze, PrognoseLimit_SOC, PrognoseMorgen, BattKapaWatt_akt_SOC, BattKapaWatt_akt,
                                    WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten,
-                                   DEBUG_Ausgabe, LadewertGrund, WR_schreiben):
+                                   DEBUG_Ausgabe, LadewertGrund, WR_schreiben, maxvolt):
 
         # Wenn Akkuschonung > 0 ab 80% Batterieladung mit Ladewert runter fahren, Werte auch für Zwangsladung bestimmen
         if Akkuschonung > 0 or Batterieentlandung_steuern > 1:
@@ -408,7 +408,7 @@ class progladewert:
             AkkuSchonGrund = Akkuschonung_dict[3]
             DEBUG_Ausgabe += Akkuschonung_dict[4]
 
-            if BattStatusProz >= BattStatusProz_Grenze_AkkuSchon and ManuelleStrg_Akkuschon == 1:
+            if BattStatusProz >= BattStatusProz_Grenze_AkkuSchon and ManuelleStrg_Akkuschon > 0:
                 # Um das setzen der Akkuschonung zu verhindern, wenn aktuellePVProduktion zu wenig oder der Akku wieder entladen wird.
                 if (AkkuschonungLadewert < aktuellerLadewert or AkkuschonungLadewert < alterLadewert + 10) and aktuellePVProduktion * HysteProdFakt > AkkuschonungLadewert:
                     aktuellerLadewert = AkkuschonungLadewert
@@ -435,18 +435,33 @@ class progladewert:
         if ManuelleStrg_Akkuschon == 0:
             DEBUG_Ausgabe += "\nDEBUG Keine Begrenzung, da Akkuschonung in LadeStrg abgewählt!"
 
-        # Begrenzung nur wenn ManuelleStrg_Akkuschon == 1
-        if BattStatusProz >= SOC_Proz_Grenze and PrognoseLimit_SOC >= 0 and PrognoseMorgen > PrognoseLimit_SOC and ManuelleStrg_Akkuschon == 1:
+        # Begrenzung nur wenn ManuelleStrg_Akkuschon > 0
+        if BattStatusProz >= SOC_Proz_Grenze and PrognoseLimit_SOC >= 0 and PrognoseMorgen > PrognoseLimit_SOC and ManuelleStrg_Akkuschon > 0:
             aktuellerLadewert = 0
             # Aufruf mit self.
             WR_schreiben = self.setLadewert(aktuellerLadewert, WRSchreibGrenze_nachOben, 0, alterLadewert)
             LadewertGrund = "Akkuschonung: Ladebegrenzung auf 80% SOC"
 
-        if BattKapaWatt_akt_SOC != BattKapaWatt_akt and ManuelleStrg_Akkuschon == 1:
+        if BattKapaWatt_akt_SOC != BattKapaWatt_akt and ManuelleStrg_Akkuschon > 0:
             DEBUG_Ausgabe += "\nDEBUG BattKapaWatt_akt orginal: " + str(BattKapaWatt_akt)
             DEBUG_Ausgabe += ", BattKapaWatt_akt um 20% gekürzt: " + str(BattKapaWatt_akt_SOC)
             DEBUG_Ausgabe+="\nDEBUG <<<< SOC 80% für Ladeberechnung AKTIV!!! >>>>"
 
+        # Wenn Akkuschonung == 2, Ladewert bei hoher Zellspannung reduzieren  #entWIGGlung
+        if Akkuschonung == 2:
+            Zellspannungs_Werte = basics.getVarConf('Ladeberechnung','Zellspannungs_Werte','str')
+            Zellspannung_ein, LadewertC, Zellspannung_aus = map(float, Zellspannungs_Werte.split(",")) # ACHTUNG Strigs
+            Volt_ladewert = int(BattganzeLadeKapazWatt_Akku * LadewertC)
+            #Zellspannung_ein = 3.31  #entWIGGlung
+            #Zellspannung_aus = 3.31  #entWIGGlung
+            #alterLadewert = 384  #entWIGGlung
+            print(f"MaxVolt = {maxvolt}V")  #entWIGGlung
+            if((alterLadewert != Volt_ladewert) and maxvolt >= Zellspannung_ein) or ((alterLadewert == Volt_ladewert) and maxvolt >= Zellspannung_aus):
+                aktuellerLadewert = Volt_ladewert
+                WR_schreiben = self.setLadewert(aktuellerLadewert, WRSchreibGrenze_nachOben, 0, alterLadewert)
+                LadewertGrund = f"Akkuschonung: Zellspannung zu hoch {maxvolt}"
+                print(f"Akkuschonung: Zellspannung zu hoch {maxvolt}")  #entWIGGlung
+        
         # Rückgabe der geänderten Variablen als Tupel
         return (aktuellerLadewert, WR_schreiben, LadewertGrund, DEBUG_Ausgabe, WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten, SOC_Proz_Grenze, AkkuschonungLadewert)
 

--- a/FUNCTIONS/PrognoseLadewert.py
+++ b/FUNCTIONS/PrognoseLadewert.py
@@ -447,20 +447,15 @@ class progladewert:
             DEBUG_Ausgabe += ", BattKapaWatt_akt um 20% gekürzt: " + str(BattKapaWatt_akt_SOC)
             DEBUG_Ausgabe+="\nDEBUG <<<< SOC 80% für Ladeberechnung AKTIV!!! >>>>"
 
-        # Wenn Akkuschonung == 2, Ladewert bei hoher Zellspannung reduzieren  #entWIGGlung
+        # Wenn Akkuschonung == 2, Ladewert bei hoher Zellspannung reduzieren
         if Akkuschonung == 2:
             Zellspannungs_Werte = basics.getVarConf('Ladeberechnung','Zellspannungs_Werte','str')
             Zellspannung_ein, LadewertC, Zellspannung_aus = map(float, Zellspannungs_Werte.split(",")) # ACHTUNG Strigs
             Volt_ladewert = int(BattganzeLadeKapazWatt_Akku * LadewertC)
-            #Zellspannung_ein = 3.31  #entWIGGlung
-            #Zellspannung_aus = 3.31  #entWIGGlung
-            #alterLadewert = 384  #entWIGGlung
-            print(f"MaxVolt = {maxvolt}V")  #entWIGGlung
             if((alterLadewert != Volt_ladewert) and maxvolt >= Zellspannung_ein) or ((alterLadewert == Volt_ladewert) and maxvolt >= Zellspannung_aus):
                 aktuellerLadewert = Volt_ladewert
                 WR_schreiben = self.setLadewert(aktuellerLadewert, WRSchreibGrenze_nachOben, 0, alterLadewert)
                 LadewertGrund = f"Akkuschonung: Zellspannung zu hoch {maxvolt}"
-                print(f"Akkuschonung: Zellspannung zu hoch {maxvolt}")  #entWIGGlung
         
         # Rückgabe der geänderten Variablen als Tupel
         return (aktuellerLadewert, WR_schreiben, LadewertGrund, DEBUG_Ausgabe, WRSchreibGrenze_nachOben, WRSchreibGrenze_nachUnten, SOC_Proz_Grenze, AkkuschonungLadewert)

--- a/FUNCTIONS/byd_status.py
+++ b/FUNCTIONS/byd_status.py
@@ -1,0 +1,41 @@
+import FUNCTIONS.functions
+import socket
+
+basics = FUNCTIONS.functions.basics()
+sqlall = FUNCTIONS.SQLall.sqlall()
+
+class BYD_Status:
+    def __init__(self):
+        self.BUFFER_SIZE = 1024
+        self.MESSAGE_2 = "01030500001984cc" #read data
+
+    def buf2int16SI(self, byteArray, pos): #signed
+        result = byteArray[pos] * 256 + byteArray[pos + 1]
+        if (result > 32768):
+            result -= 65536
+        return result
+
+    def buf2int16US(self, byteArray, pos): #unsigned
+        result = byteArray[pos] * 256 + byteArray[pos + 1]
+        return result
+
+    def read(self, byd_ip, byd_port):  
+        try:
+        
+            #connection BYD
+            client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            client.settimeout(5)  # Timeout in Sekunden
+            client.connect((byd_ip, byd_port))
+            #message 2
+            client.send(bytes.fromhex(self.MESSAGE_2))
+            #read data
+            data = client.recv(self.BUFFER_SIZE)
+            maxvolt = self.buf2int16SI(data, 5) * 1.0 / 100.0
+
+            client.close()
+
+            return maxvolt
+      
+        except Exception as ex:
+            print ("### ERROR BYD_Akku nicht erreichbar, Route, IP prüfen: ", ex)
+            return 0

--- a/FUNCTIONS/gen24_api.py
+++ b/FUNCTIONS/gen24_api.py
@@ -1,10 +1,13 @@
 import FUNCTIONS.functions
+import FUNCTIONS.SQLall
+import FUNCTIONS.byd_status
 import requests
 import json
 import re
         
 basics = FUNCTIONS.functions.basics()
 sqlall = FUNCTIONS.SQLall.sqlall()
+byd = FUNCTIONS.byd_status.BYD_Status()
 
 class InverterApi:
     def __init__(self):
@@ -147,6 +150,15 @@ class InverterApi:
                 basics.sendPush('Anlage prüfen', 'ERROR: API-Wert fehlt', 'warning')
             exit()
 
+        # Zellspannung von BYD lesen  #entWIGGlung
+        API['maxvolt'] = 0
+        Akkuschonung = basics.getVarConf('Ladeberechnung','Akkuschonung','eval')
+        if(Akkuschonung == 2):
+            akkuIP = basics.getVarConf('inverter','akkuIP','str')
+            if (akkuIP == "reserva"):
+                print("#### Reserva: Akkuschonung mit MaxVolt noch nicht eingebaut!!!")
+            else:
+                API['maxvolt'] = byd.read(akkuIP, 8080)
 
         # Daten von weiteren GEN24 lesen
         IP_weitere_Gen24 = basics.getVarConf('inverter','IP_weitere_Gen24','str')

--- a/FUNCTIONS/gen24_api.py
+++ b/FUNCTIONS/gen24_api.py
@@ -14,6 +14,79 @@ class InverterApi:
         self.dummy = 'dummmy'
 
     def extract_API_values(self, obj, key_patterns):
+        import re
+        
+        if isinstance(key_patterns, tuple):
+            key_patterns = [key_patterns]
+
+        results = {}
+        aggregates = {}
+        agg_configs = {} 
+        
+        # 1. Aggregationen vorbereiten (nur wenn mode ein String ist)
+        for entry in key_patterns:
+            pattern, mode, *maybe = entry
+            if isinstance(mode, str):
+                clean_p = re.sub(r'\[.*?\]|\(.*?\)', '', pattern).strip('_')
+                agg_name = f"{mode.upper()}_{re.sub(r'[^A-Za-z0-9_]', '_', clean_p)}"
+                
+                initial_val = 0.0
+                if mode == "max": initial_val = float('-inf')
+                elif mode == "min": initial_val = float('inf')
+                
+                aggregates[agg_name] = initial_val
+                agg_configs[pattern] = (mode, agg_name)
+
+        def recurse(o, inherited_attrs=None, inherited_label=None):
+            if isinstance(o, dict):
+                attrs = o.get("attributes", {})
+                local_label = o.get("label") or attrs.get("label")
+                active_label = local_label if local_label else inherited_label
+                
+                active_attrs = inherited_attrs.copy() if inherited_attrs else {}
+                if isinstance(attrs, dict): active_attrs.update(attrs)
+
+                for k, v in o.items():
+                    # Pattern-Matching
+                    for entry in key_patterns:
+                        pattern, mode, *maybe = entry
+                        if re.fullmatch(pattern, k):
+                            # Bedingungs-Check
+                            condition = maybe[0] if maybe else None
+                            if condition:
+                                c_type, c_val = condition
+                                if c_type == "label" and active_label != c_val: continue
+                                if c_type != "label" and active_attrs.get(c_type) != c_val: continue
+
+                            if isinstance(mode, str):
+                                # AGGREGATION
+                                m_type, name = agg_configs[pattern]
+                                try:
+                                    val = float(v)
+                                    if m_type == "sum": aggregates[name] += val
+                                    elif m_type == "max": aggregates[name] = max(aggregates[name], val)
+                                    elif m_type == "min": aggregates[name] = min(aggregates[name], val)
+                                except: pass
+                            elif k not in results:
+                                # EINZELWERT (mode ist False)
+                                results[k] = v
+
+                    if isinstance(v, (dict, list)):
+                        recurse(v, active_attrs, active_label)
+
+            elif isinstance(o, list):
+                for item in o: recurse(item, inherited_attrs, inherited_label)
+
+        recurse(obj)
+        
+        # Unendliche Werte korrigieren und Aggregationen mergen
+        for name, val in aggregates.items():
+            if val in (float('-inf'), float('inf')): val = 0.0
+            results[name] = val
+                
+        return results
+
+    def extract_API_values_old(self, obj, key_patterns):
         results = {}
         sums = {}
 
@@ -80,7 +153,8 @@ class InverterApi:
         #    data = json.load(f)
         API = {}
         # relevante API-Schlüssel definieren: 
-        # schluessel [1-3] bei mehrfachschlussel, True für Summenbildung
+        # schluessel [1-3] bei mehrfachschlussel, "sum" für Summenbildung
+        # als Aggregation kann "sum", "max" oder "min" angegeben werden
         # ("label", "<primary>") = attributes.key, Value zur Identifizierung des SM am Stromzähler, bei mehreren SM
         GEN24_API_schluessel = [
             ("nameplate", False),                                                           #BYD
@@ -92,10 +166,10 @@ class InverterApi:
             ("BAT_POWERACTIVE_MEAN_F32", False),                                            #WR   Nur vorhanden, wenn Akku an/standby
             ("BAT_ENERGYACTIVE_ACTIVECHARGE_SUM_01_U64", False),                            #WR
             ("BAT_ENERGYACTIVE_ACTIVEDISCHARGE_SUM_01_U64", False),                         #WR
-            ("PV_POWERACTIVE_MEAN_0[1-2]_F32", True),                                       #WR
-            ("ACBRIDGE_ENERGYACTIVE_PRODUCED_SUM_0[1-3]_U64", True),                        #WR
-            ("PV_ENERGYACTIVE_ACTIVE_SUM_0[1-2]_U64", True),                                #WR
-            ("ACBRIDGE_ENERGYACTIVE_ACTIVECONSUMED_SUM_0[1-3]_U64", True),                  #WR
+            ("PV_POWERACTIVE_MEAN_0[1-2]_F32", "sum"),                                       #WR
+            ("ACBRIDGE_ENERGYACTIVE_PRODUCED_SUM_0[1-3]_U64", "sum"),                        #WR
+            ("PV_ENERGYACTIVE_ACTIVE_SUM_0[1-2]_U64", "sum"),                                #WR
+            ("ACBRIDGE_ENERGYACTIVE_ACTIVECONSUMED_SUM_0[1-3]_U64", "sum"),                  #WR
             ("PS2.rev-sw", False)                                                           #WR
         ]
         API_result = self.extract_API_values(data, GEN24_API_schluessel)
@@ -150,13 +224,15 @@ class InverterApi:
                 basics.sendPush('Anlage prüfen', 'ERROR: API-Wert fehlt', 'warning')
             exit()
 
-        # Zellspannung von BYD lesen  #entWIGGlung
+        # Zellspannung von BYD oder Reserva lesen
         API['maxvolt'] = 0
         Akkuschonung = basics.getVarConf('Ladeberechnung','Akkuschonung','eval')
         if(Akkuschonung == 2):
             akkuIP = basics.getVarConf('inverter','akkuIP','str')
             if (akkuIP == "reserva"):
-                print("#### Reserva: Akkuschonung mit MaxVolt noch nicht eingebaut!!!")
+                print("#### Reserva: Akkuschonung mit MaxVolt noch nicht getestet!!!")  #entWIGGlung
+                API_result = self.extract_API_values(data, [("BATMODULE_VOLTAGE_CELL_MAX_F32", "max")])
+                API['maxvolt']   =  round(float(API_result['MAX_BATMODULE_VOLTAGE_CELL_MAX_F32']),3)
             else:
                 API['maxvolt'] = byd.read(akkuIP, 8080)
 

--- a/FUNCTIONS/ocpp.py
+++ b/FUNCTIONS/ocpp.py
@@ -28,7 +28,7 @@ import FUNCTIONS.functions
 import FUNCTIONS.SQLall
 
 basics = FUNCTIONS.functions.basics()
-_ = basics.loadConfig(['default'])
+config = basics.loadConfig(['default', 'charge'])
 # try to read configured log level; fallback handled below
 try:
     log_level = basics.getVarConf('wallbox', 'log_level', 'eval')

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,13 +8,16 @@ und eine Produktion über der AC-Ausgangsleistungsgrenze des WR als DC in die Ba
 Über die Tabelle [Ladesteuerung](#batterieladesteuerung) können große, geplante Verbräuche bei der Ladeplanung berücksichtigt werden.  
 - [Entladesteuerung,](#batterieentladesteuerung) um die Entladung der Batterie bei großen Verbräuchen zu steuern.  
 - [Logging](#-logging) und grafische Darstellung von Produktion und Verbrauch.  
-- Akkuschonung: Um einen LFP-Akku zu schonen, wird die Ladeleistung ab 80% auf 0,2C und ab 90% auf 0,1C (optional ab 95% weniger) beschränkt (anpassbar).  
+- Akkuschonung: Um einen LFP-Akku zu schonen, kann die Ladeleistung z.B. ab 80% auf 0,2C und ab 90% auf 0,1C beschränkt werden. Es ist auch eine Reduzierung der Ladeleistung in Abhängigkeit der höchsten Zellspannung möglich.  
 - [Dynamischen Strompreis](#-dynamicpricecheckpy) nutzen um bei niedrigen Preisen den Akku zu laden, mit grafischer Darstellung.  
 - **NEU:** 🚘 [Steuerung des Wattpiloten](#-wallboxsteuerung), über OCPP.  
 - [Grafana](#grafana-beispiele) Beschreibung zu Auswertungen mit Grafana inklusive fertige Dashboards von [@Manniene](https://github.com/Manniene).  
 - [Home Assistant Add-on](https://github.com/roethigj/ha_addons/tree/main/gen24_ladesteuerung) erstellt von [@roethigj](https://github.com/roethigj).  
 
 ![new](pics/new.png)  
+Ab Version: **0.41.7**  
+- Es ist nun auch eine Reduzierung der Ladeleistung in Abhängigkeit der höchsten Zellspannung möglich.  
+
 Ab Version: **0.41.0**  
 - 🚘 Steuerung des Wattpiloten, über OCPP.  
 
@@ -26,16 +29,6 @@ Ab Version: **0.40.0**
 Es ändert sich der Skriptname `http_SymoGen24Controller2.py` in `EnergyController.py`.  
 ⚠️ Die **Cronjobs** und die **default_priv.ini** müssen angepasst werden!!  
 - [WikiExtension_Gen24_Ladesteuerung von @killwack](https://github.com/killwack/WikiExtension_Gen24_Ladesteuerung/wiki)  
-
-Ab Version: **0.38.1**  
-- Mit eigenem Skript ADDONS/Fremd_API_priv.py können Produktionswerte von fremden Erzeugern geholt und an die GEN24_Ladesteuerung übergeben werden.  
-
-Ab Version: **0.38.0**  
-- Update auf Firmware 1.38.6-1.  
-
-Ab Version: **0.31.0**  
-- Updatefunktion im config-TAB, damit können `_priv.ini` Files mit den original ini-Files abgeglichen und upgedatet werden.  
-Installationsskript install_gen24.sh für eine automatische Installation bzw. Updating.  
 
 ![new](pics/new2.png)  
 
@@ -152,6 +145,13 @@ Eine [Beschreibung](../GRAFANA/Grafana_Installation_readme.pdf) und Dashboarddat
 ----------
 
 **News History:**  
+Ab Version: **0.38.1**  
+Mit eigenem Skript ADDONS/Fremd_API_priv.py können Produktionswerte von fremden Erzeugern geholt und an die GEN24_Ladesteuerung übergeben werden.  
+Ab Version: **0.38.0**  
+Update auf Firmware 1.38.6-1.  
+Ab Version: **0.31.0**  
+ Updatefunktion im config-TAB, damit können `_priv.ini` Files mit den original ini-Files abgeglichen und upgedatet werden.  
+Installationsskript install_gen24.sh für eine automatische Installation bzw. Updating.  
 Ab Version: **0.30.4**  
 Neues Prognoseskripte OpenMeteo_WeatherData.py für https://open-meteo.com.  
 Ab Version: **0.30.2**  

--- a/docs/WIKI/LadeStrg.html
+++ b/docs/WIKI/LadeStrg.html
@@ -10,20 +10,26 @@
       margin-top: 20px;
     }
 
-    </style>  
+    </style>
   </head>
   <body lang="de-DE">
-    <div class="weatherDataManager"> <a href="#weatherDataManager"><b>Hilfe ForecastMgr</b></a></div>
-    <!--HIERZURUECK-->
-    <br>
-    <center> 
-    <p> <h2><b><span style="background: #44c767">TAB</span>--&gt; LadeSteuerung</b></h2></p>
+    <div class="weatherDataManager"> <a href="#weatherDataManager"><b>Hilfe
+
+          ForecastMgr</b></a></div>
+    <!--HIERZURUECK--> <br>
+    <center>
+      <p> </p>
+      <h2><b><span style="background: #44c767">TAB</span>--&gt;
+          LadeSteuerung</b></h2>
+      <p></p>
       <p>Im Dropdown unter "Ladegrenze" kann ausgewählt werden, wie die
         Hausakkuladung erfolgen soll.<br>
         Für die Auswahl <b>Slider</b> oder <b>MaxLadung </b>kann hier
         mit dem Optionsfeld <b>Ladegrenze mit Akkuschonung</b>,<br>
         gewählt werden, ob die Akkuschonung angewendet wird, ansonsten
-        wird mit der eingestellten Ladeleistung vollgeladen. </p>
+        wird mit der eingestellten Ladeleistung vollgeladen.<br>
+        Ist in CONFIG/charge_priv.ini Akkuschonung über Zellspannung
+        (=2) eingetragen,&nbsp; wird diese auch hier angewendet. </p>
       <table>
         <tbody>
           <tr>
@@ -77,7 +83,7 @@
     </center>
     <hr width="100%" size="2">
     <h2 class="western" align="center"> <a name="weatherDataManager"><br>
-    </a>Prognoseberechnung und ForecastMgr</h2>
+      </a>Prognoseberechnung und ForecastMgr</h2>
     <p align="center"><br>
     </p>
     <p align="left">Grundsätzliches:</p>

--- a/docs/WIKI/config.html
+++ b/docs/WIKI/config.html
@@ -220,28 +220,31 @@ Fast-forward
 <tr class="comment"><td colspan="2">; Das Kennwort muss in einfache Hochkommas gesetzt werden, wegen evtl. Sonderzeichen<br>; sollte das Kennwort ein % enthalten bitte zwei %% eintragen. </td></tr>
 <tr><td class="variablenname">password</td>
 <td><input type="text" name="Zeile[19][1]" value="&#039;XXXXXXXX&#039;" readonly></td></tr>
+<tr class="comment"><td colspan="2">; hier IP des BYD_Akku oder bei Fronius-Reserva reserva eintragen<br>; Um den Zugriff auf den BYD_Akku zu ermöglichen, muss ein Routing zu 192.168.16.254<br>; entweder am Rechner oder am Router eingetragen sein. </td></tr>
+<tr><td class="variablenname">akkuIP</td>
+<td><input type="text" name="Zeile[21][1]" value="192.168.178.222" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Akkukapazität in Wh, wird benötigt, wenn Akku offline ist!! </td></tr>
 <tr><td class="variablenname">battery_capacity_Wh</td>
-<td><input type="text" name="Zeile[21][1]" value="11000" readonly></td></tr>
-<tr><td colspan="2"><input type="hidden" name="Zeile[22]" value='' ></td></tr>
-<tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[23]" value='[wallbox]' >[wallbox]</td></tr>
+<td><input type="text" name="Zeile[23][1]" value="11000" readonly></td></tr>
+<tr><td colspan="2"><input type="hidden" name="Zeile[24]" value='' ></td></tr>
+<tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[25]" value='[wallbox]' >[wallbox]</td></tr>
 <tr class="comment"><td colspan="2">; wenn wallboxsteuerung = 1, dann wird durch start_PythonScript.sh der ocpp_server gestartet.<br>; Konfiguration und Steuerung des OCPP-Servers erfolgt über den TAB Wattpilot der WebUI </td></tr>
 <tr><td class="variablenname">wallboxsteuerung</td>
-<td><input type="text" name="Zeile[25][1]" value="0" readonly></td></tr>
+<td><input type="text" name="Zeile[27][1]" value="0" readonly></td></tr>
 <tr class="comment"><td colspan="2">; ocpp_log_level steuert das logging des OCPP-Servers<br>; 0=ERROR/WARN, 1=+/OK 2=+INFO, 3=+NOTE </td></tr>
 <tr><td class="variablenname">log_level</td>
-<td><input type="text" name="Zeile[27][1]" value="3" readonly></td></tr>
-<tr><td colspan="2"><input type="hidden" name="Zeile[28]" value='' ></td></tr>
-<tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[29]" value='[messaging]' >[messaging]</td></tr>
+<td><input type="text" name="Zeile[29][1]" value="3" readonly></td></tr>
+<tr><td colspan="2"><input type="hidden" name="Zeile[30]" value='' ></td></tr>
+<tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[31]" value='[messaging]' >[messaging]</td></tr>
 <tr class="comment"><td colspan="2">; Hier können Pushmessages zu den Schreibvorgängen über den Dienst ntfy.sh auf die Handyapp ntfy gesendet werden.<br>; Push_Message_EIN (1=EIN/0=AUS)<br>; Die Adresse des über die App erstellten Themennamen eintragen. </td></tr>
 <tr><td class="variablenname">Push_Message_EIN</td>
-<td><input type="text" name="Zeile[31][1]" value="0" readonly></td></tr>
-<tr class="comment"><td colspan="2">; Wenn ERROR_Push_Message_EIN = 1, werden Pushmessages bei Harwareausfall versendet.<br>; z.B. Smartmeter, Akku oder Wechselrichter ist nicht erreichbar </td></tr>
+<td><input type="text" name="Zeile[33][1]" value="0" readonly></td></tr>
+<tr class="comment"><td colspan="2">; Wenn ERROR_Push_Message_EIN = 1, werden Pushmessages bei Hardwareausfall versendet.<br>; z.B. Smartmeter, Akku oder Wechselrichter ist nicht erreichbar </td></tr>
 <tr><td class="variablenname">ERROR_Push_Message_EIN</td>
-<td><input type="text" name="Zeile[33][1]" value="1" readonly></td></tr>
+<td><input type="text" name="Zeile[35][1]" value="1" readonly></td></tr>
 <tr><td class="variablenname">Push_Message_Url</td>
-<td><input type="text" name="Zeile[34][1]" value="https://ntfy.sh/XXXXXXXXX" readonly></td></tr>
-<tr><td colspan="2"><input type="hidden" name="Zeile[35]" value='' ></td></tr>
+<td><input type="text" name="Zeile[36][1]" value="https://ntfy.sh/XXXXXXXXX" readonly></td></tr>
+<tr><td colspan="2"><input type="hidden" name="Zeile[37]" value='' ></td></tr>
 </table><div id="Hilfezu/CONFIG/defaultini"></div><br><center><a href="#Hilfezu/CONFIG/weatherini" style="font-size: 2.0rem; text-decoration: none;">▼</a>&nbsp;&nbsp;<button type="submit">Hilfe zu weather.ini</button>&nbsp;&nbsp;<a href="#top" style="font-size: 2.0rem; text-decoration: none;">▲</a></center><br><br><table><tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[0]" value='[Hinweis]' >[Hinweis]</td></tr>
 <tr class="comment"><td colspan="2">; Bitte die original weather.ini nicht ändern, da sie bei Updates überschrieben wird.<br>; Persönliche Anpassungen stattdessen in einer Kopie als weather_priv.ini ablegen. </td></tr>
 <tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[2]" value='[env]' >[env]</td></tr>
@@ -455,60 +458,63 @@ Fast-forward
 <tr><td class="variablenname">GrenzwertGroestePrognose</td>
 <td><input type="text" name="Zeile[36][1]" value="2000" readonly></td></tr>
 <tr><td colspan="2"><input type="hidden" name="Zeile[37]" value='' ></td></tr>
-<tr class="comment"><td colspan="2">; Akkuschonung (0=aus, 1=ein)<br>; Wenn Akkuschonung ein, wird BattVollUm um eine Stunde vor verlegt, da am Schluss nicht mehr so stark geladen wird.<br>; ACHTUNG: Eine Überschreitung der Einspeisegrenze bzw. AC-Leistung des WR setzt die Akkuschonung aus! </td></tr>
+<tr class="comment"><td colspan="2">; Akkuschonung (0=aus, 1=ein, 2=ein+Zellspannungs_Werte)<br>; Wenn Akkuschonung ein (1 oder 2), wird BattVollUm um die berechnete Verzögerung vorverlegt, da am Schluss nicht mehr so stark geladen wird.<br>; ACHTUNG: Eine Überschreitung der Einspeisegrenze bzw. AC-Leistung des WR setzt die Akkuschonung aus! </td></tr>
 <tr><td class="variablenname">Akkuschonung</td>
 <td><input type="text" name="Zeile[39][1]" value="1" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Akkuschonung_Werte = {&quot;Ladestand%&quot; : &quot;LadewertC&quot;, ...}<br>; Akkuschonung_Ladewert = ((Akkukapazität * SOH / 100) * LadewertC), aufgerundet auf ganze 10 Watt.<br>; Heißt, der Akkuzustand wird hier wie auch bei anderen Berechnungen angehalten. </td></tr>
 <tr><td class="variablenname">Akkuschonung_Werte</td>
 <td><input type="text" name="Zeile[41][1]" value="{&quot;80&quot;: &quot;0.2&quot;, &quot;90&quot;: &quot;0.1&quot;, &quot;95&quot;: &quot;0.05&quot;}" readonly></td></tr>
+<tr class="comment"><td colspan="2">; Akkuschonung = 2: Liegt die maximale Zellspannung der Akkuzellen über Zellspannung_ein wird zwingend der Ladewert LadewertC gesetzt,<br>; unter Zellspannung_aus wird wieder der anderweitig berechnete Ladewert angehalten.<br>; Zellspannungs_Werte = Zellspannung_ein,LadewertC,Zellspannung_aus </td></tr>
+<tr><td class="variablenname">Zellspannungs_Werte</td>
+<td><input type="text" name="Zeile[43][1]" value="3.42,0.03,3.38" readonly></td></tr>
 <tr class="comment"><td colspan="2">; bei Prognosemorgen über diesem Wert in kW, wird die Akkuladung auf X% begrenzt,<br>; wenn nicht manuelle Strg ohne Akkuschonung ausgewählt ist.<br>; X ist der erste Wert aus dem String Akkuschonung_Werte<br>; bei einem Wert -1 ist die Funktion abgeschaltet </td></tr>
 <tr><td class="variablenname">PrognoseLimit_SOC</td>
-<td><input type="text" name="Zeile[43][1]" value="-1" readonly></td></tr>
-<tr><td colspan="2"><input type="hidden" name="Zeile[44]" value='' ></td></tr>
-<tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[45]" value='[monats_priv.ini]' >[monats_priv.ini]</td></tr>
+<td><input type="text" name="Zeile[45][1]" value="-1" readonly></td></tr>
+<tr><td colspan="2"><input type="hidden" name="Zeile[46]" value='' ></td></tr>
+<tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[47]" value='[monats_priv.ini]' >[monats_priv.ini]</td></tr>
 <tr class="comment"><td colspan="2">; hier können die Namen von zusätzlichen monatsabhängigen config.ini definiert werden.<br>; die Monate müssen immer zweistellig sein!!<br>; Dateiname (immer Kleinbuchstaben) = GültigkeitsMonate<br>; winter_priv.ini = 11, 12, 01 </td></tr>
-<tr><td colspan="2"><input type="hidden" name="Zeile[47]" value='' ></td></tr>
-<tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[48]" value='[Entladung]' >[Entladung]</td></tr>
+<tr><td colspan="2"><input type="hidden" name="Zeile[49]" value='' ></td></tr>
+<tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[50]" value='[Entladung]' >[Entladung]</td></tr>
 <tr class="comment"><td colspan="2">; Konfigdaten für die Entladesteuerung<br>; Batterieentladung und Zwangsladung ein- bzw. ausschalten (1=ein, 0=aus, 2=Ein+Akkuschonung bei Zwangsladung) </td></tr>
 <tr><td class="variablenname">Batterieentlandung_steuern</td>
-<td><input type="text" name="Zeile[50][1]" value="0" readonly></td></tr>
+<td><input type="text" name="Zeile[52][1]" value="0" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Damit nicht so häufig auf dem WR geschrieben wird nur bei Abweichung größer WRSchreibGrenze_Watt schreiben </td></tr>
 <tr><td class="variablenname">WREntladeSchreibGrenze_Watt</td>
-<td><input type="text" name="Zeile[52][1]" value="200" readonly></td></tr>
+<td><input type="text" name="Zeile[54][1]" value="200" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Feste Entladebegrenzung ab einem bestimmten Verbrauch (Angaben in Watt)<br>; Funktion nur aktiv, wenn Verbrauch_Feste_Entladegrenze &gt; 0 (z.B. 10000 Watt für Wallbox)<br>; Ist der Verbrauch über Verbrauch_Feste_Entladegrenze, wird die Entnahme aus dem Akku auf Feste_Entladegrenze begrenzt </td></tr>
 <tr><td class="variablenname">Verbrauch_Feste_Entladegrenze</td>
-<td><input type="text" name="Zeile[54][1]" value="0" readonly></td></tr>
+<td><input type="text" name="Zeile[56][1]" value="0" readonly></td></tr>
 <tr><td class="variablenname">Feste_Entladegrenze</td>
-<td><input type="text" name="Zeile[55][1]" value="300" readonly></td></tr>
-<tr><td colspan="2"><input type="hidden" name="Zeile[56]" value='' ></td></tr>
-<tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[57]" value='[Notstrom]' >[Notstrom]</td></tr>
+<td><input type="text" name="Zeile[57][1]" value="300" readonly></td></tr>
+<tr><td colspan="2"><input type="hidden" name="Zeile[58]" value='' ></td></tr>
+<tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[59]" value='[Notstrom]' >[Notstrom]</td></tr>
 <tr class="comment"><td colspan="2">; Notstromreservekapazität auf bestimmten Prozentsatz begrenzen (1=ein, 0=aus) </td></tr>
 <tr><td class="variablenname">Notstromreserve_steuern</td>
-<td><input type="text" name="Zeile[59][1]" value="0" readonly></td></tr>
+<td><input type="text" name="Zeile[61][1]" value="0" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Notstromreservekapazität Minimum normalerweise 5% kann hier höher gesetzt werden </td></tr>
 <tr><td class="variablenname">Notstromreserve_Min</td>
-<td><input type="text" name="Zeile[61][1]" value="5" readonly></td></tr>
+<td><input type="text" name="Zeile[63][1]" value="5" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Notstrom_Werte = {&quot;PrognoseGrenzeMorgen/kWh&quot; : &quot;Notstromreservekapazität/%&quot;, ...} </td></tr>
 <tr><td class="variablenname">Notstrom_Werte</td>
-<td><input type="text" name="Zeile[63][1]" value="{&quot;9&quot;: &quot;30&quot;}" readonly></td></tr>
-<tr><td colspan="2"><input type="hidden" name="Zeile[64]" value='' ></td></tr>
-<tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[65]" value='[EigenverbOptimum]' >[EigenverbOptimum]</td></tr>
+<td><input type="text" name="Zeile[65][1]" value="{&quot;9&quot;: &quot;30&quot;}" readonly></td></tr>
+<tr><td colspan="2"><input type="hidden" name="Zeile[66]" value='' ></td></tr>
+<tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[67]" value='[EigenverbOptimum]' >[EigenverbOptimum]</td></tr>
 <tr class="comment"><td colspan="2">; Nur HTTP<br>; durch das Setzen eines bestimmten Einspeisewertes unter Eigenverbrauchs-Optimierung<br>; kann über Nacht der Akku entladen werden<br>; EigenverbOpt_steuern 0 = aus, 1 = ein und Tagesoptimierung nach Prognose, 2 = nachts ein und tags aus </td></tr>
 <tr><td class="variablenname">EigenverbOpt_steuern</td>
-<td><input type="text" name="Zeile[67][1]" value="0" readonly></td></tr>
+<td><input type="text" name="Zeile[69][1]" value="0" readonly></td></tr>
 <tr><td class="variablenname">GrundlastNacht</td>
-<td><input type="text" name="Zeile[68][1]" value="340" readonly></td></tr>
+<td><input type="text" name="Zeile[70][1]" value="340" readonly></td></tr>
 <tr><td class="variablenname">AkkuZielProz</td>
-<td><input type="text" name="Zeile[69][1]" value="40" readonly></td></tr>
+<td><input type="text" name="Zeile[71][1]" value="40" readonly></td></tr>
 <tr><td class="variablenname">MaxEinspeisung</td>
-<td><input type="text" name="Zeile[70][1]" value="200" readonly></td></tr>
+<td><input type="text" name="Zeile[72][1]" value="200" readonly></td></tr>
 <tr class="comment"><td colspan="2">; der zu schreibende Wert wird auf RundungEinspeisewert gerundet, um die Schreibzugriffe zu minimieren </td></tr>
 <tr><td class="variablenname">RundungEinspeisewert</td>
-<td><input type="text" name="Zeile[72][1]" value="100" readonly></td></tr>
+<td><input type="text" name="Zeile[74][1]" value="100" readonly></td></tr>
 <tr class="comment"><td colspan="2">; PrognoseGrenzeMorgen in KWh </td></tr>
 <tr><td class="variablenname">PrognoseGrenzeMorgen</td>
-<td><input type="text" name="Zeile[74][1]" value="30" readonly></td></tr>
-<tr><td colspan="2"><input type="hidden" name="Zeile[75]" value='' ></td></tr>
+<td><input type="text" name="Zeile[76][1]" value="30" readonly></td></tr>
+<tr><td colspan="2"><input type="hidden" name="Zeile[77]" value='' ></td></tr>
 </table><div id="Hilfezu/CONFIG/chargeini"></div><br><center><a href="#Hilfezu/CONFIG/dynpriceini" style="font-size: 2.0rem; text-decoration: none;">▼</a>&nbsp;&nbsp;<button type="submit">Hilfe zu dynprice.ini</button>&nbsp;&nbsp;<a href="#top" style="font-size: 2.0rem; text-decoration: none;">▲</a></center><br><br><table><tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[0]" value='[Hinweis]' >[Hinweis]</td></tr>
 <tr class="comment"><td colspan="2">; Bitte die original dynprice.ini nicht ändern, da sie bei Updates überschrieben wird.<br>; Persönliche Anpassungen stattdessen in einer Kopie als dynprice_priv.ini ablegen. </td></tr>
 <tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[2]" value='[dynprice]' >[dynprice]</td></tr>
@@ -666,6 +672,6 @@ Fast-forward
 <td><input type="text" name="Zeile[55][1]" value="ein" readonly></td></tr>
 <tr><td colspan="2"><input type="hidden" name="Zeile[56]" value='' ></td></tr>
 <tr><td colspan="2"><input type="hidden" name="Zeile[57]" value='' ></td></tr>
-</table><div id="Hilfezu/CONFIG//html/configini"></div><br /><br /><hr />Hilfe erzeugt am 12.03.2026 durch make_config_help.php&nbsp;&nbsp;<a href="#top" style="font-size: 2.0rem; text-decoration: none;">▲</a><br />
+</table><div id="Hilfezu/CONFIG//html/configini"></div><br /><br /><hr />Hilfe erzeugt am 02.04.2026 durch make_config_help.php&nbsp;&nbsp;<a href="#top" style="font-size: 2.0rem; text-decoration: none;">▲</a><br />
 </body>
 </html>

--- a/docs/WIKI/config.html
+++ b/docs/WIKI/config.html
@@ -458,15 +458,15 @@ Fast-forward
 <tr><td class="variablenname">GrenzwertGroestePrognose</td>
 <td><input type="text" name="Zeile[36][1]" value="2000" readonly></td></tr>
 <tr><td colspan="2"><input type="hidden" name="Zeile[37]" value='' ></td></tr>
-<tr class="comment"><td colspan="2">; Akkuschonung (0=aus, 1=ein, 2=ein+Zellspannungs_Werte)<br>; Wenn Akkuschonung ein (1 oder 2), wird BattVollUm um die berechnete Verzögerung vorverlegt, da am Schluss nicht mehr so stark geladen wird.<br>; ACHTUNG: Eine Überschreitung der Einspeisegrenze bzw. AC-Leistung des WR setzt die Akkuschonung aus! </td></tr>
+<tr class="comment"><td colspan="2">; Akkuschonung (0=aus, 1=ein, 2=ein+Zellspannungs_Werte)<br>; Wenn Akkuschonung ein (1 oder 2), wird BattVollUm um die berechnete Verzögerung vorverlegt, da am Schluss nicht mehr so stark geladen wird.<br>; ACHTUNG: Bei Akkuschonung = 2, akkuIP in default_priv.ini richtig konfigurieren </td></tr>
 <tr><td class="variablenname">Akkuschonung</td>
 <td><input type="text" name="Zeile[39][1]" value="1" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Akkuschonung_Werte = {&quot;Ladestand%&quot; : &quot;LadewertC&quot;, ...}<br>; Akkuschonung_Ladewert = ((Akkukapazität * SOH / 100) * LadewertC), aufgerundet auf ganze 10 Watt.<br>; Heißt, der Akkuzustand wird hier wie auch bei anderen Berechnungen angehalten. </td></tr>
 <tr><td class="variablenname">Akkuschonung_Werte</td>
-<td><input type="text" name="Zeile[41][1]" value="{&quot;80&quot;: &quot;0.2&quot;, &quot;90&quot;: &quot;0.1&quot;, &quot;95&quot;: &quot;0.05&quot;}" readonly></td></tr>
+<td><input type="text" name="Zeile[41][1]" value="{&quot;80&quot;: &quot;0.2&quot;, &quot;90&quot;: &quot;0.1&quot;, &quot;96&quot;: &quot;0.02&quot;}" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Akkuschonung = 2: Liegt die maximale Zellspannung der Akkuzellen über Zellspannung_ein wird zwingend der Ladewert LadewertC gesetzt,<br>; unter Zellspannung_aus wird wieder der anderweitig berechnete Ladewert angehalten.<br>; Zellspannungs_Werte = Zellspannung_ein,LadewertC,Zellspannung_aus </td></tr>
 <tr><td class="variablenname">Zellspannungs_Werte</td>
-<td><input type="text" name="Zeile[43][1]" value="3.42,0.03,3.38" readonly></td></tr>
+<td><input type="text" name="Zeile[43][1]" value="3.40,0.03,3.37" readonly></td></tr>
 <tr class="comment"><td colspan="2">; bei Prognosemorgen über diesem Wert in kW, wird die Akkuladung auf X% begrenzt,<br>; wenn nicht manuelle Strg ohne Akkuschonung ausgewählt ist.<br>; X ist der erste Wert aus dem String Akkuschonung_Werte<br>; bei einem Wert -1 ist die Funktion abgeschaltet </td></tr>
 <tr><td class="variablenname">PrognoseLimit_SOC</td>
 <td><input type="text" name="Zeile[45][1]" value="-1" readonly></td></tr>
@@ -672,6 +672,6 @@ Fast-forward
 <td><input type="text" name="Zeile[55][1]" value="ein" readonly></td></tr>
 <tr><td colspan="2"><input type="hidden" name="Zeile[56]" value='' ></td></tr>
 <tr><td colspan="2"><input type="hidden" name="Zeile[57]" value='' ></td></tr>
-</table><div id="Hilfezu/CONFIG//html/configini"></div><br /><br /><hr />Hilfe erzeugt am 02.04.2026 durch make_config_help.php&nbsp;&nbsp;<a href="#top" style="font-size: 2.0rem; text-decoration: none;">▲</a><br />
+</table><div id="Hilfezu/CONFIG//html/configini"></div><br /><br /><hr />Hilfe erzeugt am 03.04.2026 durch make_config_help.php&nbsp;&nbsp;<a href="#top" style="font-size: 2.0rem; text-decoration: none;">▲</a><br />
 </body>
 </html>

--- a/version.ini
+++ b/version.ini
@@ -1,2 +1,2 @@
 [Programm]
-version = v0.41.6
+version = v0.41.7


### PR DESCRIPTION
- Akkuschonung: Nun kann der Ladewert auch über diie höchste Zellspannung gesteuert werden.  
  **Änderung in CONFIG/default.ini** im Block `[inverter]` wurde hierzu die Variable `akkuIP` eingefügt, in `priv.ini` nachziehen.  
  **Änderung in CONFIG/charge.ini** im Block `[Ladeberechnung]` wurde hierzu die Variable `Zellspannungs_Werte` eingefügt, in `priv.ini` nachziehen.  i
       Wird Akkuschonung = 2 gesetzt, wird die höchste Zellspannung zur Ladeleistungsreduktion verwendet.  
