### PR TITLE
v0.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-**[0.42.0] – 2026-XX-XX**  
+**[0.42.0] – 2026-04-28**  
 - Wallboxsteuerung: NextTrip mit notwendigen Anpassungen im Frontend hinzugefügt.  
 - Wallboxsteuerung: Option zu Begrenzung der Ladeleistung des Hausakkus hinzugefügt.  
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**[0.42.0] – 2026-XX-XX**  
+- Wallboxsteuerung: NextTrip mit notwendigen Anpassungen im Frontend hinzugefügt.  
+
 **[0.41.8] – 2026-04-16**  
 - FIX: start_PythonScript.sh -o Logfile mit absolutem Pfad erzeugte Fehler, z.B. beim Start des Dockers.  
 - FIX OCPP-Server: Keine Werte an Wallbox senden, wenn keine Auto angesteckt ist.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 **[0.42.0] – 2026-XX-XX**  
 - Wallboxsteuerung: NextTrip mit notwendigen Anpassungen im Frontend hinzugefügt.  
+- Wallboxsteuerung: Option zu Begrenzung der Ladeleistung des Hausakkus hinzugefügt.  
 
 **[0.41.8] – 2026-04-16**  
 - FIX: start_PythonScript.sh -o Logfile mit absolutem Pfad erzeugte Fehler, z.B. beim Start des Dockers.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 - Wallboxsteuerung: NextTrip mit notwendigen Anpassungen im Frontend hinzugefügt.  
 - Wallboxsteuerung: Option zu Begrenzung der Ladeleistung des Hausakkus hinzugefügt.  
 
+- Änderungen an den Prognoseskripten und in der CONFIG/weather.ini bzw. CONFIG/weather_priv.ini  
+  Alle Prognosedienste können nun mit der Variablen `offset_minuten` die Prognose verschieben.  
+  Deshalb wurde die Variable in den Blöcken der jeweiligen Prognosedienste hinzugefügt.  
+  **Änderungen in CONFIG/weather.ini**, bitte in `priv.ini` nachziehen.  
+
 **[0.41.8] – 2026-04-16**  
 - FIX: start_PythonScript.sh -o Logfile mit absolutem Pfad erzeugte Fehler, z.B. beim Start des Dockers.  
 - FIX OCPP-Server: Keine Werte an Wallbox senden, wenn keine Auto angesteckt ist.  

--- a/CONFIG/charge.ini
+++ b/CONFIG/charge.ini
@@ -91,7 +91,6 @@ Notstromreserve_Min = 5
 Notstrom_Werte = {"9": "30"}
 
 [EigenverbOptimum]
-; Nur HTTP
 ; durch das Setzen eines bestimmten Einspeisewertes unter Eigenverbrauchs-Optimierung
 ; kann über Nacht der Akku entladen werden
 ; EigenverbOpt_steuern 0 = aus, 1 = ein und Tagesoptimierung nach Prognose, 2 = nachts ein und tags aus

--- a/CONFIG/weather.ini
+++ b/CONFIG/weather.ini
@@ -38,6 +38,9 @@ horizon2 = 0,10,10,10,30,30,0,0,10,10,10,0
 
 
 [forecast.solar]
+; Wenn die Prognosekurve zur Produktionskurve generell verschoben ist, kann die Zeit hiermit um X Minuten verschoben werden
+; Positive Werte = früher (nach links),negative = später (nach rechts).
+offset_minuten = 0
 ; Wenn api_key nicht "kein" ist, wird er für die Prognoseabfrage verwendet.
 api_key = kein
 ; wenn ein API key vorhanden ist, können die Forecasts mit aktuellen Ertragswerten des Tages (aus der DB) verbessert werden.
@@ -58,6 +61,9 @@ Gewicht = 1
 [akkudoktor]
 ; spezifische Werte für die API von Andreas Schmitz, dem Akkudoktor https://www.youtube.com/@Akkudoktor
 ; weitere Infos unter https://api.akkudoktor.net/
+; Wenn die Prognosekurve zur Produktionskurve generell verschoben ist, kann die Zeit hiermit um X Minuten verschoben werden
+; Positive Werte = früher (nach links),negative = später (nach rechts).
+offset_minuten = 0
 ; der Zellkoeffizient wird für die Berechnung der Verluste im Kontext herrschender Temperaturen genutzt
 cellco = -0.4
 ; albedo ist der Reflexionsgrad des Untergrunds, auf dem die Zellen montiert sind. Siehe https://pv-navi.de/pv-navi-abc/albedo/
@@ -81,8 +87,9 @@ accesstoken = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 item = inverter
 id = 1111
 type = hourly
-; der Zeitversatz verschiebt die Prognose um X Stunden nach vor (-) oder nach hinten.
-Zeitversatz = 0
+; Wenn die Prognosekurve zur Produktionskurve generell verschoben ist, kann die Zeit hiermit um X Minuten verschoben werden
+; Positive Werte = früher (nach links),negative = später (nach rechts).
+offset_minuten = 0
 ; Sekunden des sleep = Vorgabe von solarprognose.de
 WaitSec = 21
 ; mögliche Werte mosmix|own-v1|clearsky, für mosmix muss dem Standort eine Mosmix Station zugeordnet sein.
@@ -100,6 +107,9 @@ api_key = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 resource_id = xxxx-xxxx-xxxx-xxxx
 ; Zeitversatz zu UTC, hier für Zeitzone Europe/Berlin UTC +1, Sommerzeit = +1 erfolgt nun automatisch.
 Zeitzone = +1
+; Wenn die Prognosekurve zur Produktionskurve generell verschoben ist, kann die Zeit hiermit um X Minuten verschoben werden
+; Positive Werte = früher (nach links),negative = später (nach rechts).
+offset_minuten = 0
 KW_Faktor = 1.00
 ; spezifische Werte für eventuellen 2. String:
 resource_id2 = xxxx-xxxx-xxxx-xxxx
@@ -110,7 +120,8 @@ Gewicht = 1
 
 [openmeteo]
 ; Infos zur API siehe https://open-meteo.com/en/docs
-; Wenn die Prognosekurve zur Produktionskurve generell verschoben ist, kann sie hiermit um X Minuten verschoben werden
+; Wenn die Prognosekurve zur Produktionskurve generell verschoben ist, kann die Zeit hiermit um X Minuten verschoben werden
+; Positive Werte = früher (nach links),negative = später (nach rechts).
 offset_minuten = 0
 ; Faktor des zusätzlichen Bewölkungseinflusses
 ; 0 = kein Einfluss => 1.0 starker Einfluss

--- a/FORECAST/Akkudoktor__WeatherData.py
+++ b/FORECAST/Akkudoktor__WeatherData.py
@@ -89,13 +89,14 @@ if __name__ == '__main__':
     config = basics.loadConfig(['default', 'weather'])
     ForecastCalcMethod = basics.getVarConf('env','ForecastCalcMethod','str')
     Gewicht = basics.getVarConf('akkudoktor','Gewicht','eval')
+    offset_minuten = basics.getVarConf('akkudoktor','offset_minuten','eval')
     Quelle = 'akkudoktor'
     
     format = "%H:%M:%S"    
     now = datetime.now()    
     data = loadLatestWeatherData(Quelle, Gewicht)
     if isinstance(data, list):
-        weatherdata.storeWeatherData_SQL(data, Quelle, Gewicht)
+        weatherdata.storeWeatherData_SQL(data, Quelle, Gewicht, '', offset_minuten)
         # Ergebnis mit ForecastCalcMethod berechnen und in DB speichern
         weatherdata.store_forecast_result()
         print(f'{Quelle} OK: Prognosedaten und Ergebnisse ({ForecastCalcMethod}) {now.strftime(format)} gespeichert.\n')

--- a/FORECAST/Forecast_solar__WeatherData.py
+++ b/FORECAST/Forecast_solar__WeatherData.py
@@ -115,6 +115,7 @@ if __name__ == '__main__':
     basics = FUNCTIONS.functions.basics()
     weatherdata = FUNCTIONS.WeatherData.WeatherData()
     config = basics.loadConfig(['default', 'weather'])
+    offset_minuten = basics.getVarConf('forecast.solar','offset_minuten','eval')
     ForecastCalcMethod = basics.getVarConf('env','ForecastCalcMethod','str')
     Gewicht = basics.getVarConf('forecast.solar','Gewicht','eval')
     Quelle = 'forecast.solar'
@@ -123,7 +124,7 @@ if __name__ == '__main__':
     now = datetime.now()    
     data = loadLatestWeatherData(Quelle, Gewicht)
     if isinstance(data, list):
-        weatherdata.storeWeatherData_SQL(data, Quelle, Gewicht)
+        weatherdata.storeWeatherData_SQL(data, Quelle, Gewicht, '', offset_minuten)
         # Ergebnis mit ForecastCalcMethod berechnen und in DB speichern
         weatherdata.store_forecast_result()
         print(f'{Quelle} OK: Prognosedaten und Ergebnisse ({ForecastCalcMethod}) {now.strftime(format)} gespeichert.\n')

--- a/FORECAST/OpenMeteo_WeatherData.py
+++ b/FORECAST/OpenMeteo_WeatherData.py
@@ -27,36 +27,6 @@ except ImportError:
             return datetime.timedelta(hours=1)
 
 
-def interpolate_at_offset(data, offset_minuten=0):
-    times_iso = data["hourly"]["time"]
-    irradiance = data["hourly"]["global_tilted_irradiance"]
-
-    # Zeiten in datetime-Objekte umwandeln
-    times_dt = [datetime.datetime.fromisoformat(t) for t in times_iso]
-
-    interpolated_values = []
-
-    for i in range(len(times_dt)):
-        offset_time = times_dt[i] + datetime.timedelta(minutes=offset_minuten)
-
-        # Nach Intervall suchen, das die Offset-Zeit umschließt
-        interpolated = 0
-        for j in range(len(times_dt) - 1):
-            t1, t2 = times_dt[j], times_dt[j + 1]
-            v1, v2 = irradiance[j], irradiance[j + 1]
-
-            if t1 <= offset_time <= t2 and v1 is not None and v2 is not None:
-                ratio = (offset_time - t1).total_seconds() / (t2 - t1).total_seconds()
-                interpolated = int(v1 + (v2 - v1) * ratio)
-                break  # Interpolation gefunden
-
-        interpolated_values.append(interpolated)
-
-    # Neues Feld ergänzen, Zeit bleibt unverändert
-    data["hourly"]["global_tilted_irradiance"] = interpolated_values
-
-    return data
-
 def compute_mean_field(data, prefix, target_field):
     # Falls das Zielfeld schon existiert, nichts tun
     if target_field in data['hourly']:
@@ -109,7 +79,6 @@ def get_pv_forecast_icon_d2_cloud_layers(quelle, gewicht):
     cloudEffect = basics.getVarConf('openmeteo','cloudEffect','eval')
     # Basis-Effizienzfaktor (systemische Verluste, nicht-optimale Bedingungen)
     base_efficiency_factor = basics.getVarConf('openmeteo','base_efficiency_factor','eval')
-    offset_minuten = basics.getVarConf('openmeteo','offset_minuten','eval')
 
     start_date = now_local.strftime('%Y-%m-%d')
     end_date = (now_local + datetime.timedelta(days=2)).strftime('%Y-%m-%d')
@@ -156,10 +125,6 @@ def get_pv_forecast_icon_d2_cloud_layers(quelle, gewicht):
         # Mittelwerte berechnen
         data = compute_mean_field(data, 'global_tilted_irradiance_', 'global_tilted_irradiance')
         data = compute_mean_field(data, 'cloud_cover_', 'cloud_cover')
-
-        # Offset anwenden, wenn nicht 0
-        if (offset_minuten != 0):
-            data = interpolate_at_offset(data, offset_minuten)
 
         pv_forecast_data = []
         if "hourly" in data and "time" in data["hourly"] and "global_tilted_irradiance" in data["hourly"]:
@@ -244,7 +209,7 @@ if __name__ == "__main__":
     data = get_pv_forecast_icon_d2_cloud_layers(Quelle, Gewicht)
 
     if isinstance(data, list):
-        weatherdata.storeWeatherData_SQL(data, Quelle, Gewicht)
+        weatherdata.storeWeatherData_SQL(data, Quelle, Gewicht, '', offset_minuten)
         # Ergebnis mit ForecastCalcMethod berechnen und in DB speichern
         weatherdata.store_forecast_result()
         print(f'{Quelle} OK: Prognosedaten und Ergebnisse ({ForecastCalcMethod}) {now_local.strftime(format)} gespeichert.\n')

--- a/FORECAST/Solarprognose_WeatherData.py
+++ b/FORECAST/Solarprognose_WeatherData.py
@@ -26,7 +26,7 @@ def loadLatestWeatherData(Quelle, Gewicht):
         exit()
     dict_watts = {}
     for key, value in json_data1.get('data',{}).items():
-        key_neu = str(datetime.fromtimestamp(value[0]) + timedelta(hours=Zeitversatz))
+        key_neu = str(datetime.fromtimestamp(value[0]))
         dict_watts[key_neu] = int(value[1]*1000*KW_Faktor)
 
     # Daten für SQL erzeugen
@@ -52,7 +52,7 @@ if __name__ == '__main__':
     accesstoken = basics.getVarConf('solarprognose', 'accesstoken', 'str')
     item = basics.getVarConf('solarprognose', 'item', 'str')
     type = basics.getVarConf('solarprognose', 'type', 'str')
-    Zeitversatz = int(basics.getVarConf('solarprognose', 'Zeitversatz', 'eval'))
+    offset_minuten = int(basics.getVarConf('solarprognose', 'offset_minuten', 'eval'))
     algorithm = basics.getVarConf('solarprognose', 'algorithm', 'str')
 
     time.sleep(WaitSec)
@@ -64,7 +64,7 @@ if __name__ == '__main__':
     data = data_all[0]
     data_err = data_all[1]
     if isinstance(data, list):
-        weatherdata.storeWeatherData_SQL(data, Quelle, Gewicht)
+        weatherdata.storeWeatherData_SQL(data, Quelle, Gewicht, '', offset_minuten)
         # Ergebnis mit ForecastCalcMethod berechnen und in DB speichern
         weatherdata.store_forecast_result()
         print(f'{Quelle} OK: Prognosedaten und Ergebnisse ({ForecastCalcMethod}) {now.strftime(format)} gespeichert.\n')

--- a/FORECAST/Solcast_WeatherData.py
+++ b/FORECAST/Solcast_WeatherData.py
@@ -121,6 +121,7 @@ if __name__ == '__main__':
     # Benoetigte Variablen definieren und prüfen
     Strings = basics.getVarConf('pv.strings', 'anzahl', 'eval')
     Zeitzone = basics.getVarConf('solcast.com', 'Zeitzone', 'eval')
+    offset_minuten = int(basics.getVarConf('solcast.com', 'offset_minuten', 'eval'))
     KW_Faktor = basics.getVarConf('solcast.com', 'KW_Faktor', 'eval')
     KW_Faktor2 = basics.getVarConf('solcast.com', 'KW_Faktor2', 'eval')
     api_key = basics.getVarConf('solcast.com', 'api_key', 'str')
@@ -136,7 +137,7 @@ if __name__ == '__main__':
     data = data_all[0]
     data_err = data_all[1]
     if isinstance(data, list):
-        weatherdata.storeWeatherData_SQL(data, Quelle, Gewicht)
+        weatherdata.storeWeatherData_SQL(data, Quelle, Gewicht, '', offset_minuten)
         # Ergebnis mit ForecastCalcMethod berechnen und in DB speichern
         weatherdata.store_forecast_result()
         print(f'{Quelle} OK: Prognosedaten und Ergebnisse ({ForecastCalcMethod}) {now.strftime(format)} gespeichert.\n')

--- a/FUNCTIONS/PrognoseLadewert.py
+++ b/FUNCTIONS/PrognoseLadewert.py
@@ -410,7 +410,7 @@ class progladewert:
 
             if BattStatusProz >= BattStatusProz_Grenze_AkkuSchon and ManuelleStrg_Akkuschon > 0:
                 # Um das setzen der Akkuschonung zu verhindern, wenn aktuellePVProduktion zu wenig oder der Akku wieder entladen wird.
-                if (AkkuschonungLadewert < aktuellerLadewert or AkkuschonungLadewert < alterLadewert + 10) and aktuellePVProduktion * HysteProdFakt > AkkuschonungLadewert:
+                if (AkkuschonungLadewert < aktuellerLadewert) and (aktuellePVProduktion * HysteProdFakt > AkkuschonungLadewert):
                     aktuellerLadewert = AkkuschonungLadewert
                     WRSchreibGrenze_nachUnten = aktuellerLadewert / 5
                     WRSchreibGrenze_nachOben = aktuellerLadewert / 5

--- a/FUNCTIONS/SQLall.py
+++ b/FUNCTIONS/SQLall.py
@@ -164,11 +164,15 @@ class sqlall:
         columns = [col[0] for col in zeiger.description]
         for row in rows:
             data[row[0]] = {}
-            # Hier nur Zahlen zulassen
-            try:
-                data[row[0]][columns[1]] = float(row[1])
-            except (ValueError, TypeError):
-                data[row[0]][columns[1]] = 0
+            # Hier nur Zahlen zulassen, wenn schlussel nicht wallbox
+            if schluessel != 'wallbox':
+                try:
+                    data[row[0]][columns[1]] = float(row[1])
+                except (ValueError, TypeError):
+                    data[row[0]][columns[1]] = 0
+            else:
+                # Bei wallbox den Wert einfach direkt übernehmen
+                data[row[0]][columns[1]] = row[1]
 
             # Feld 2 kann String enthalten, wegen viertestündlichen Strompreisen
             data[row[0]][columns[2]] = row[2]

--- a/FUNCTIONS/WeatherData.py
+++ b/FUNCTIONS/WeatherData.py
@@ -44,13 +44,141 @@ class WeatherData:
         print("DB",path,"wurde erstellt.")
 
 
-    def storeWeatherData_SQL(self, data, quelle, gewicht_neu=-1, loesche_quelle=''):
+    def apply_minute_offset(self, data, offset_minutes):
+        """
+        Verschiebt die Prognosewerte um offset_minutes.
+        Positive Werte = später (nach rechts), negative = früher (nach links).
+        Die Zeitstempel bleiben auf vollen Stunden, die Werte werden interpoliert.
+        """
+        if offset_minutes == 0:
+            return data
+    
+        from datetime import datetime, timedelta
+    
+        dt_format = "%Y-%m-%d %H:%M:%S"
+    
+        times = [datetime.strptime(entry[0], dt_format) for entry in data]
+        values = [entry[2] for entry in data]
+
+        def interpolate_value(target_dt):
+            source_dt = target_dt - timedelta(minutes=offset_minutes)
+
+            hour_before = source_dt.replace(minute=0, second=0, microsecond=0)
+            hour_after = hour_before + timedelta(hours=1)
+
+            val_before = None
+            val_after = None
+            for i, t in enumerate(times):
+                if t == hour_before:
+                    val_before = values[i]
+                if t == hour_after:
+                    val_after = values[i]
+
+            if val_before is None and val_after is None:
+                return 0  # Außerhalb des Datenbereichs
+            if val_before is None:
+                return val_after
+            if val_after is None:
+                return val_before
+
+            frac = (source_dt - hour_before).seconds / 3600.0
+            return val_before + (val_after - val_before) * frac
+
+        new_data = []
+        for i, entry in enumerate(data):
+            target_dt = times[i]
+            new_value = interpolate_value(target_dt)
+
+            new_entry = (
+                entry[0],
+                entry[1],
+                round(new_value),
+                entry[3],
+                entry[4],
+            )
+            new_data.append(new_entry)
+
+        return new_data
+
+    def WIGGAL_apply_minute_offset(self, data, offset_minutes):
+        """
+        Verschiebt die Prognosewerte um offset_minutes.
+        Positive Werte = früher (nach links),negative = später (nach rechts).
+        Die Zeitstempel bleiben auf vollen Stunden, die Werte werden interpoliert.
+        """
+        if offset_minutes == 0:
+            return data
+
+        # um keine verdrehte Verschiebung zu erhalten
+        offset_minutes = -offset_minutes
+        # Index aufbauen: Zeitpunkt -> (index, entry)
+        dt_format = "%Y-%m-%d %H:%M:%S"
+
+        # Zeitstempel als datetime-Objekte extrahieren
+        times = [datetime.strptime(entry[0], dt_format) for entry in data]
+        values = [entry[2] for entry in data]
+
+        # Hilfsfunktion: Wert zu einem bestimmten Zeitpunkt interpolieren
+        def interpolate_value(target_dt):
+            # Originalzeit minus Offset = wo im Original nachschauen
+            source_dt = target_dt - timedelta(minutes=offset_minutes)
+
+            # Nächste Stunden-Grenzen im Original finden
+            hour_before = source_dt.replace(minute=0, second=0, microsecond=0)
+            hour_after = hour_before + timedelta(hours=1)
+
+            # Werte an den Stundengrenzen suchen
+            val_before = None
+            val_after = None
+            for i, t in enumerate(times):
+                if t == hour_before:
+                    val_before = values[i]
+                if t == hour_after:
+                    val_after = values[i]
+
+            if val_before is None and val_after is None:
+                return None  # Außerhalb des Datenbereichs
+            if val_before is None:
+                return val_after
+            if val_after is None:
+                return val_before
+
+            # Lineare Interpolation
+            frac = (source_dt - hour_before).seconds / 3600.0
+            return val_before + (val_after - val_before) * frac
+
+        # Neue Daten mit interpolierten Werten aufbauen
+        new_data = []
+        for i, entry in enumerate(data):
+            target_dt = times[i]
+            new_value = interpolate_value(target_dt)
+
+            if new_value is None:
+                # Außerhalb des Datenbereichs -> Originalwert behalten oder 0
+                new_value = entry[2]
+
+            new_entry = (
+                entry[0],           # Zeitstempel unverändert
+                entry[1],           # Quelle unverändert
+                round(new_value),   # Interpolierter Wert (gerundet auf int)
+                entry[3],           # Gewicht unverändert
+                entry[4],           # Options unverändert
+        )
+            new_data.append(new_entry)
+
+        return new_data
+
+    def storeWeatherData_SQL(self, data, quelle, gewicht_neu=-1, loesche_quelle='', offset_minutes=0):
         self.check_or_create_db('weatherData.sqlite')
         verbindung = sqlite3.connect('weatherData.sqlite')
         zeiger = verbindung.cursor()
         print_level = basics.getVarConf('env','print_level','eval')
         # Alte Einträge löschen die älter 35 Tage sind
         loesche_bis = (datetime.today() - timedelta(days=35)).date().isoformat()
+
+        # Minutenoffset anwenden
+        if offset_minutes != 0 and gewicht_neu != -1:
+            data = self.apply_minute_offset(data, offset_minutes * -1)
 
         #Prognosen kleiner 10W löschen
         data = [entry for entry in data if entry[2] >= 10 or entry[1] == "Produktion"]
@@ -305,7 +433,7 @@ class WeatherData:
         DB_data.extend(Prognose)
             
         # Speichern der Resultate  in DB
-        self.storeWeatherData_SQL(DB_data, 'Basis, Prognose, Produktion', '-1', loesche_quelle)
+        self.storeWeatherData_SQL(DB_data, 'Basis, Prognose, Produktion', -1, loesche_quelle)
         conn.close()
 
         return()

--- a/FUNCTIONS/ocpp.py
+++ b/FUNCTIONS/ocpp.py
@@ -522,8 +522,8 @@ class OCPPManager:
         else:
             batterie_anteil = max(self.max_leistung_ha, min(self.Batteriebezug, 0.0)) ##WIGGAL
         self.hausverbrauch = max(0.0, self.Produktion + self.Batteriebezug + self.Netzbezug - current_charge_power)
-        ueberschuss = int(max(0.0, self.Produktion + batterie_anteil + self.Netzbezug - self.residualPower))
-        #print("==>>>WIGGAL", self.max_leistung_ha, batterie_anteil)
+        ueberschuss = int(max(0.0, (self.Produktion - self.hausverbrauch + batterie_anteil - self.residualPower)))
+        print("==>>>WIGGAL", self.max_leistung_ha, batterie_anteil)
 
         cinfo(f"[{'..' + cp_id[-4:]}] Ladeberechnung: PV={self.Produktion} W, Akku={self.Batteriebezug} W, Netz={self.Netzbezug} W, Haus={self.hausverbrauch} W, CP={current_charge_power} W, Überschuss={ueberschuss} W")
 

--- a/FUNCTIONS/ocpp.py
+++ b/FUNCTIONS/ocpp.py
@@ -413,7 +413,7 @@ class OCPPManager:
                     except Exception:
                         pass
                     try:
-                        raw_ha = row4.get('Res_Feld2')
+                        raw_ha = row4.get('Options')
                         if raw_ha is not None:
                             self.max_leistung_ha = float(raw_ha)*-1
                     except Exception:
@@ -522,7 +522,8 @@ class OCPPManager:
         else:
             batterie_anteil = max(self.max_leistung_ha, min(self.Batteriebezug, 0.0)) ##WIGGAL
         self.hausverbrauch = max(0.0, self.Produktion + self.Batteriebezug + self.Netzbezug - current_charge_power)
-        ueberschuss = max(0.0, (self.Produktion - self.hausverbrauch + batterie_anteil - self.residualPower))
+        ueberschuss = int(max(0.0, self.Produktion + batterie_anteil + self.Netzbezug - self.residualPower))
+        #print("==>>>WIGGAL", self.max_leistung_ha, batterie_anteil)
 
         cinfo(f"[{'..' + cp_id[-4:]}] Ladeberechnung: PV={self.Produktion} W, Akku={self.Batteriebezug} W, Netz={self.Netzbezug} W, Haus={self.hausverbrauch} W, CP={current_charge_power} W, Überschuss={ueberschuss} W")
 

--- a/FUNCTIONS/ocpp.py
+++ b/FUNCTIONS/ocpp.py
@@ -177,7 +177,7 @@ class ChargePointHandler:
         s.transaction_id = None
         s.debug = []
 
-        # NEU: Zähler beim ersten Verbinden auf 0 setzen  #entWIGGlung
+        # NEU: Zähler beim ersten Verbinden auf 0 setzen
         s.charged_wh = 0.0
         s.last_energy_wh = None
 
@@ -259,7 +259,8 @@ class ChargePointHandler:
                 await self.send_callresult(uid, {"idTagInfo": {"status": "Accepted"}, "transactionId": tx_id})
             elif action == "StopTransaction":
                 self.state.transaction_id = None
-                self.state.status = "Available"
+                # NICHT self.state.status = "Available" setzen!
+                # Die Wallbox schickt danach StatusNotification (z.B. "Finishing" oder "SuspendedEVSE")
                 self.state.transaction_start = None
                 await self.send_callresult(uid, {"idTagInfo": {"status": "Accepted"}})
             else:
@@ -302,6 +303,7 @@ class OCPPManager:
         self.MIN_CHARGE_DURATION_S = 600
         self.PHASE_CHANGE_CONFIRM_S = 30
         self.residualPower = -300.0
+        self.max_leistung_ha = 0.1
         self.DEFAULT_TARGET_KWH = 0.0
 
         # NextTrip (PV-Mode 4) Ladezeiten aus DB (ID=4)
@@ -410,6 +412,12 @@ class OCPPManager:
                                 self.wb_ladezeit_bis = b
                     except Exception:
                         pass
+                    try:
+                        raw_ha = row4.get('Res_Feld2')
+                        if raw_ha is not None:
+                            self.max_leistung_ha = float(raw_ha)*-1
+                    except Exception:
+                        pass
                 # update autosync interval
                 self.auto_sync_interval = getattr(self, 'AUTO_SYNC_INTERVAL', self.auto_sync_interval)
             except Exception:
@@ -498,11 +506,21 @@ class OCPPManager:
         phases_to_use = self.wb_phases
 
         current_charge_power = 0
+        # NEU (echter Messwert, konsistent mit HTTP-Endpoint):
         if cp_id and cp_id in self.states:
-            current_charge_power = self.get_current_power(cp_id)
+            current_charge_power = self._extract_power_w_from_meter_store(cp_id)
+            st = self.states[cp_id]
+            # Fallback auf Schätzung wenn noch keine MeterValues vorliegen
+            if current_charge_power == 0.0 and st.current_limit and st.phase_limit:
+                if st.status in ["Charging", "ChargingRequested"]:
+                    current_charge_power = self.get_current_power(cp_id)
 
         # Inverter-Werte verrechnen
-        batterie_anteil = self.Batteriebezug if self.Batteriebezug < 0 else 0.0
+        # Wert "-inf" wäre unendlich = keine Begrenzung ##WIGGAL
+        if self.max_leistung_ha > 0:
+            batterie_anteil = self.Batteriebezug
+        else:
+            batterie_anteil = max(self.max_leistung_ha, min(self.Batteriebezug, 0.0)) ##WIGGAL
         self.hausverbrauch = max(0.0, self.Produktion + self.Batteriebezug + self.Netzbezug - current_charge_power)
         ueberschuss = max(0.0, (self.Produktion - self.hausverbrauch + batterie_anteil - self.residualPower))
 

--- a/FUNCTIONS/ocpp.py
+++ b/FUNCTIONS/ocpp.py
@@ -768,29 +768,40 @@ class OCPPManager:
                     st.append_debug({"note": "stop-guard-applied", "amp": amp_allowed, "ts": iso_now()})
                 else:
                     if active_tx_id and amp_allowed == 0.0:
-                        # Stop-Hysterese: kurze Unterschreitungen abfangen
-                        now = datetime.now()
-                        if st.stop_candidate is None:
-                            st.stop_candidate = now
-                            amp_allowed = amp_min or self.wb_amp_min
-                            cinfo(f"[{st.log_cp_id}] Stop-Hysterese gestartet – warte {self.PHASE_CHANGE_CONFIRM_S}s vor Stopp")
-                            st.append_debug({"note": "stop-hysteresis-start", "ts": iso_now()})
-                        else:
-                            elapsed = (now - st.stop_candidate).total_seconds()
-                            if elapsed < self.PHASE_CHANGE_CONFIRM_S:
-                                remaining_s = int(self.PHASE_CHANGE_CONFIRM_S - elapsed)
+                        if is_pv_controlled:
+                            # Stop-Hysterese: kurze PV-Unterschreitungen abfangen
+                            now = datetime.now()
+                            if st.stop_candidate is None:
+                                st.stop_candidate = now
                                 amp_allowed = amp_min or self.wb_amp_min
-                                cinfo(f"[{st.log_cp_id}] Stop-Hysterese aktiv – noch {remaining_s}s warten vor Stopp")
-                                st.append_debug({"note": "stop-hysteresis-wait", "remaining_s": remaining_s, "ts": iso_now()})
+                                cinfo(f"[{st.log_cp_id}] Stop-Hysterese gestartet – warte {self.PHASE_CHANGE_CONFIRM_S}s vor Stopp")
+                                st.append_debug({"note": "stop-hysteresis-start", "ts": iso_now()})
                             else:
-                                st.stop_candidate = None
-                                cinfo(f"[{st.log_cp_id}] Stop-Hysterese bestätigt – stoppe Laden")
-                                handler = ChargePointHandler(self, st)
-                                await handler.send_call("RemoteStopTransaction", {"transactionId": active_tx_id})
-                                st.transaction_id = None
-                                st.status = "AvailableRequested"
-                                st.transaction_start = None
-                                st.append_debug({"note": "remote-stop-sent", "ts": iso_now()})
+                                elapsed = (now - st.stop_candidate).total_seconds()
+                                if elapsed < self.PHASE_CHANGE_CONFIRM_S:
+                                    remaining_s = int(self.PHASE_CHANGE_CONFIRM_S - elapsed)
+                                    amp_allowed = amp_min or self.wb_amp_min
+                                    cinfo(f"[{st.log_cp_id}] Stop-Hysterese aktiv – noch {remaining_s}s warten vor Stopp")
+                                    st.append_debug({"note": "stop-hysteresis-wait", "remaining_s": remaining_s, "ts": iso_now()})
+                                else:
+                                    st.stop_candidate = None
+                                    cinfo(f"[{st.log_cp_id}] Stop-Hysterese bestätigt – stoppe Laden")
+                                    handler = ChargePointHandler(self, st)
+                                    await handler.send_call("RemoteStopTransaction", {"transactionId": active_tx_id})
+                                    st.transaction_id = None
+                                    st.status = "AvailableRequested"
+                                    st.transaction_start = None
+                                    st.append_debug({"note": "remote-stop-sent", "ts": iso_now()})
+                        else:
+                            # PV-Mode=0 oder andere nicht-PV-Modi → sofort stoppen
+                            st.stop_candidate = None
+                            cinfo(f"[{st.log_cp_id}] Kein PV-Modus – stoppe sofort")
+                            handler = ChargePointHandler(self, st)
+                            await handler.send_call("RemoteStopTransaction", {"transactionId": active_tx_id})
+                            st.transaction_id = None
+                            st.status = "AvailableRequested"
+                            st.transaction_start = None
+                            st.append_debug({"note": "remote-stop-sent", "ts": iso_now()})
                     elif active_tx_id:
                         # amp_allowed > 0 → Laden gewünscht, Stop-Kandidat zurücksetzen
                         st.stop_candidate = None

--- a/FUNCTIONS/ocpp.py
+++ b/FUNCTIONS/ocpp.py
@@ -657,10 +657,12 @@ class OCPPManager:
             # verbose info for current state including PV mode and charged Wh
             cinfo(f"[{st.log_cp_id}] PV-Mode={pv_mode}, PV-Steuerung={is_pv_controlled}, Wunsch: {amp_desired}A/{requested_phase}P, Aktuell: {st.current_limit}A/{st.phase_limit}P, Geladen: {charged_wh}Wh")
 
-            # PHASE HYSTERESE: nur wenn Änderung, nicht initial, und Laden > 0 gewünscht
+            # PHASE HYSTERESE: nur wenn Änderung, nicht initial, Laden > 0 gewünscht
+            # UND automatische Phasenwahl aktiv (wb_phases == "0")
+            # Bei fester Phaseneinstellung (1 oder 3) keine Hysterese nötig
             is_charging_requested = amp_desired > 0.0
             candidate = st.phase_candidate
-            if phase_changed and not is_initial_change and is_charging_requested:
+            if phase_changed and not is_initial_change and is_charging_requested and self.wb_phases == "0":
                 now = datetime.now()
                 if not candidate or candidate.get('requested') != requested_phase:
                     st.phase_candidate = {'requested': requested_phase, 'since': now}
@@ -725,7 +727,9 @@ class OCPPManager:
                         duration = (datetime.now() - st.transaction_start).total_seconds()
                         if duration < self.MIN_CHARGE_DURATION_S:
                             can_stop = False
-                            st.append_debug({"note": "stop-guard", "remaining_s": int(self.MIN_CHARGE_DURATION_S - duration), "ts": iso_now()})
+                            remaining_s = int(self.MIN_CHARGE_DURATION_S - duration)
+                            cinfo(f"[{st.log_cp_id}] Stop-Guard aktiv – noch {remaining_s}s warten (Mindestladezeit={self.MIN_CHARGE_DURATION_S}s)")
+                            st.append_debug({"note": "stop-guard", "remaining_s": remaining_s, "ts": iso_now()})
                     if target_kwh and (charged_wh >= target_kwh * 1000.0):
                         can_stop = True
 

--- a/FUNCTIONS/ocpp.py
+++ b/FUNCTIONS/ocpp.py
@@ -218,15 +218,29 @@ class ChargePointHandler:
 
             if action == "BootNotification":
                 await self.send_callresult(uid, {"currentTime": now_iso_future(), "interval": 300, "status": "Accepted"})
-                # refresh global/config values and apply for this CP
+                # refresh global/config values; apply verzögert damit StatusNotification zuerst eintreffen kann
                 self.manager.refresh_wallbox_settings(cp_id=self.state.cp_id, use_cache=True)
-                # schedule apply (do not await)
-                asyncio.create_task(self.manager.apply_wallbox_settings(self.state.cp_id))
+                async def _delayed_apply(cp_id, delay=15):
+                    await asyncio.sleep(delay)
+                    await self.manager.apply_wallbox_settings(cp_id)
+                asyncio.create_task(_delayed_apply(self.state.cp_id))
             elif action == "Heartbeat":
                 await self.send_callresult(uid, {"currentTime": now_iso_future()})
             elif action == "StatusNotification":
-                self.state.status = payload.get("status", self.state.status)
+                new_status = payload.get("status", self.state.status)
+                old_status = self.state.status
+                self.state.status = new_status
                 await self.send_callresult(uid)
+                # Fahrzeug hat Laden beendet/pausiert → sofort Limit auf 0 setzen
+                if new_status == "SuspendedEV" and old_status != "SuspendedEV":
+                    cinfo(f"[{self.state.log_cp_id}] Fahrzeug hat Laden pausiert (SuspendedEV) – setze Limit auf 0.0A")
+                    if self.state.phase_limit is not None:
+                        try:
+                            await self.send_call("SetChargingProfile", charging_profile_payload(0.0, self.state.phase_limit))
+                            self.state.current_limit = 0.0
+                            self.state.append_debug({"note": "status-suspended-ev-immediate-zero", "ts": iso_now()})
+                        except Exception:
+                            cerr_exc(f"Fehler beim Setzen auf 0A bei SuspendedEV fuer {self.state.cp_id}")
             elif action == "MeterValues":
                 if payload.get("transactionId"):
                     self.state.transaction_id = payload["transactionId"]
@@ -289,6 +303,10 @@ class OCPPManager:
         self.PHASE_CHANGE_CONFIRM_S = 30
         self.residualPower = -300.0
         self.DEFAULT_TARGET_KWH = 0.0
+
+        # NextTrip (PV-Mode 4) Ladezeiten aus DB (ID=4)
+        self.wb_ladezeit_von: str = "22:00"   # Res_Feld1
+        self.wb_ladezeit_bis: str = "06:00"   # Res_Feld2
 
         # Inverter / energy cache (updated each autosync iteration)
         self.Netzbezug = 0.0
@@ -373,6 +391,25 @@ class OCPPManager:
                             self.PHASE_CHANGE_CONFIRM_S = int(float(opt3))
                     except Exception:
                         pass
+                # ID=4: NextTrip Ladezeiten
+                row4 = data.get('4') or data.get(4)
+                if row4:
+                    try:
+                        raw_v = row4.get('Res_Feld1')
+                        if raw_v is not None:
+                            v = str(raw_v).strip()
+                            if v:
+                                self.wb_ladezeit_von = v
+                    except Exception:
+                        pass
+                    try:
+                        raw_b = row4.get('Res_Feld2')
+                        if raw_b is not None:
+                            b = str(raw_b).strip()
+                            if b:
+                                self.wb_ladezeit_bis = b
+                    except Exception:
+                        pass
                 # update autosync interval
                 self.auto_sync_interval = getattr(self, 'AUTO_SYNC_INTERVAL', self.auto_sync_interval)
             except Exception:
@@ -390,7 +427,8 @@ class OCPPManager:
                     f"{self.MIN_CHARGE_DURATION_S}, "
                     f"{self.PHASE_CHANGE_CONFIRM_S}, "
                     f"{self.residualPower}, "
-                    f"{self.DEFAULT_TARGET_KWH}"
+                    f"{self.DEFAULT_TARGET_KWH}, "
+                    f"NextTrip={self.wb_ladezeit_von}–{self.wb_ladezeit_bis}"
                 )
 
 
@@ -417,8 +455,33 @@ class OCPPManager:
                 st.append_debug({"note": "target synced to DEFAULT", "value": self.DEFAULT_TARGET_KWH, "ts": iso_now()})
 
     # ----------------------------
-    # PV / Limit-Berechnung
+    # NextTrip: Zeitfenster-Prüfung
     # ----------------------------
+    def _is_in_nexttrip_window(self) -> bool:
+        """
+        Gibt True zurück, wenn die aktuelle Uhrzeit im Zeitfenster
+        [wb_ladezeit_von .. wb_ladezeit_bis] liegt.
+        Unterstützt Fenster über Mitternacht, z.B. 22:00 – 06:00.
+        """
+        try:
+            now_t = datetime.now().time().replace(second=0, microsecond=0)
+            def parse_t(s: str):
+                h, m = map(int, s.strip().split(":"))
+                from datetime import time as dtime
+                return dtime(h, m)
+            t_von = parse_t(self.wb_ladezeit_von)
+            t_bis = parse_t(self.wb_ladezeit_bis)
+            if t_von <= t_bis:
+                # normales Fenster z.B. 08:00 – 14:00
+                return t_von <= now_t <= t_bis
+            else:
+                # über Mitternacht z.B. 22:00 – 06:00
+                return now_t >= t_von or now_t <= t_bis
+        except Exception:
+            cwarn(f"NextTrip: Ungültige Zeitangabe von='{self.wb_ladezeit_von}' bis='{self.wb_ladezeit_bis}'")
+            return False
+
+
     def compute_limits_from_global(self, cp_id: Optional[str] = None) -> Tuple[float, str, float, bool, float]:
         """
         Berechnet Limits basierend auf PV-Überschuss und DB-Vorgaben.
@@ -498,6 +561,26 @@ class OCPPManager:
             # nimm den aktuell zulässigen Max-Wert (oder zulässiges Minimum falls kleiner)
             amp = max(self.MIN_WB_AMP, min(self.wb_amp_max, self.MAX_WB_AMP))
 
+        elif float(self.wb_pv_mode) == 4.0:
+            # PV-Mode = 4  -> NextTrip: Laden im Zeitfenster mit Max-Leistung bis Lademenge erreicht
+            is_pv_controlled = False
+            if self.wb_phases == "0":
+                phases_to_use = "3"
+            else:
+                phases_to_use = self.wb_phases or "3"
+            if self._is_in_nexttrip_window():
+                amp = max(self.MIN_WB_AMP, min(self.wb_amp_max, self.MAX_WB_AMP))
+                cinfo(
+                    f"NextTrip: im Zeitfenster {self.wb_ladezeit_von}–{self.wb_ladezeit_bis} "
+                    f"→ {amp}A / {phases_to_use}P"
+                )
+            else:
+                amp = 0.0
+                cinfo(
+                    f"NextTrip: außerhalb Zeitfenster {self.wb_ladezeit_von}–{self.wb_ladezeit_bis} "
+                    f"→ kein Laden"
+                )
+
         self.wb_amp = amp
         self.wb_is_pv_controlled = is_pv_controlled
 
@@ -537,15 +620,26 @@ class OCPPManager:
             self.refresh_wallbox_settings(cp_id=cp_id, use_cache=True)
             amp, phases, pv_mode, is_pv_controlled, amp_min = self.compute_limits_from_global(cp_id=cp_id)
 
-            """ Status nicht eindeutig.   #entWIGGlung
-            print("Wallboxstatus: ", st.status)  #entWIGGlung
-            # ---- Nur Werte senden wenn Auto angesteckt ist ----  #entWIGGlung
-            plugged_states = ["Preparing", "Charging", "SuspendedEV", "SuspendedEVSE", "Finishing"]
+            # ---- Nur Werte senden wenn Fahrzeug angesteckt ist ----
+            plugged_states = ["Preparing", "Charging", "SuspendedEV", "SuspendedEVSE", "Finishing",
+                              "ChargingRequested", "AvailableRequested"]
             if st.status not in plugged_states and not st.transaction_id:
-                cwarn(f"[{st.cp_id}] Kein Fahrzeug angesteckt (Status={st.status}) – keine Werte an Wallbox gesendet")
+                cdebug(f"[{st.log_cp_id}] Kein Fahrzeug angesteckt (Status={st.status}) – keine Werte gesendet")
                 return False
             # ---------------------------------------------------
-            """
+
+            # ---- SuspendedEV: Fahrzeug hat Laden pausiert → stop-guard überspringen, Limit auf 0 ----
+            if st.status == "SuspendedEV":
+                if st.current_limit != 0.0:
+                    handler = ChargePointHandler(self, st)
+                    await handler.send_call("SetChargingProfile", charging_profile_payload(0.0, st.phase_limit or 3))
+                    st.current_limit = 0.0
+                    st.append_debug({"note": "suspended-ev-limit-set-zero", "ts": iso_now()})
+                    cinfo(f"[{st.log_cp_id}] Fahrzeug angesteckt (Status=SuspendedEV) – SetChargingProfile 0.0A nach OCPP")
+                else:
+                    cdebug(f"[{st.log_cp_id}] Fahrzeug angesteckt (Status=SuspendedEV) – bereits 0.0A, kein Senden")
+                return False
+            # -----------------------------------------------------------------------
 
             # desired values
             amp_desired = amp if pv_mode != 0.0 else 0.0
@@ -603,6 +697,15 @@ class OCPPManager:
             # Start/Stop decision
             if amp_allowed > 0.0 and amp_allowed >= 6.0:
                 if status in ["Available", "AvailableRequested", "SuspendedEVSE", "Finishing"]:
+                    # Vor RemoteStart: offene Transaktion beenden (Wallbox würde sonst ablehnen)
+                    if active_tx_id:
+                        cinfo(f"[{st.log_cp_id}] Offene Transaktion {active_tx_id} vor Neustart beenden")
+                        handler = ChargePointHandler(self, st)
+                        await handler.send_call("RemoteStopTransaction", {"transactionId": active_tx_id})
+                        st.transaction_id = None
+                        st.transaction_start = None
+                        active_tx_id = None
+                        await asyncio.sleep(2)
                     # request remote start
                     handler = ChargePointHandler(self, st)
                     await handler.send_call("RemoteStartTransaction", {"connectorId": DEFAULT_CONNECTOR_ID, "idTag": DEFAULT_IDTAG})
@@ -612,14 +715,19 @@ class OCPPManager:
                     st.append_debug({"note": "start-requested", "amp": amp_allowed, "ts": iso_now()})
             else:
                 # STOP-GUARD prüfung
-                can_stop = True
-                if is_pv_controlled and st.transaction_start:
-                    duration = (datetime.now() - st.transaction_start).total_seconds()
-                    if duration < self.MIN_CHARGE_DURATION_S:
-                        can_stop = False
-                        st.append_debug({"note": "stop-guard", "remaining_s": int(self.MIN_CHARGE_DURATION_S - duration), "ts": iso_now()})
-                if target_kwh and (charged_wh >= target_kwh * 1000.0):
+                # SuspendedEV = Fahrzeug hat aktiv Laden verweigert → stop-guard greift NICHT
+                if status == "SuspendedEV":
                     can_stop = True
+                    cdebug(f"[{st.log_cp_id}] Stop-Guard übersprungen – Fahrzeug in SuspendedEV")
+                else:
+                    can_stop = True
+                    if is_pv_controlled and st.transaction_start:
+                        duration = (datetime.now() - st.transaction_start).total_seconds()
+                        if duration < self.MIN_CHARGE_DURATION_S:
+                            can_stop = False
+                            st.append_debug({"note": "stop-guard", "remaining_s": int(self.MIN_CHARGE_DURATION_S - duration), "ts": iso_now()})
+                    if target_kwh and (charged_wh >= target_kwh * 1000.0):
+                        can_stop = True
 
                 if not can_stop:
                     amp_allowed = amp_min or self.wb_amp_min
@@ -633,9 +741,22 @@ class OCPPManager:
                         st.transaction_start = None
                         st.append_debug({"note": "remote-stop-sent", "ts": iso_now()})
                     elif status not in ["Available", "AvailableRequested"]:
-                        st.status = "Available"
-                        st.transaction_start = None
-                        st.append_debug({"note": "status-set-available", "ts": iso_now()})
+                        # Nur auf Available setzen wenn Fahrzeug NICHT angesteckt ist
+                        physically_plugged = status in ["SuspendedEVSE", "Preparing", "Finishing", "SuspendedEV"]
+                        if not physically_plugged:
+                            st.status = "Available"
+                            st.transaction_start = None
+                            st.append_debug({"note": "status-set-available", "ts": iso_now()})
+                        else:
+                            # Fahrzeug angesteckt aber kein Laden gewünscht → nur einmal 0A senden
+                            phase_for_zero = st.phase_limit or 3
+                            if st.current_limit != 0.0:
+                                handler = ChargePointHandler(self, st)
+                                await handler.send_call("SetChargingProfile", charging_profile_payload(0.0, phase_for_zero))
+                                st.current_limit = 0.0
+                                cinfo(f"[{st.log_cp_id}] Fahrzeug angesteckt (Status={status}) – SetChargingProfile 0.0A nach OCPP")
+                            else:
+                                cdebug(f"[{st.log_cp_id}] Fahrzeug angesteckt (Status={status}) – bereits 0.0A, kein Senden")
 
             # ---------------------------
             # AMPERE-ANPASSUNG WÄHREND DER PHASEN-HYSTERESE (wie Original)
@@ -647,13 +768,23 @@ class OCPPManager:
                 current_p = st.phase_limit
                 if current_p is not None:
                     if requested_p > current_p and amp_allowed != 16.0:
-                        st.append_debug({"note": "phase-up-temporary-16", "ts": iso_now()})
-                        amp_allowed = 16.0
-                        amp_changed = True
+                        if st.current_limit != 16.0:
+                            st.append_debug({"note": "phase-up-temporary-16", "ts": iso_now()})
+                            amp_allowed = 16.0
+                            amp_changed = True
+                        else:
+                            # bereits 16A gesetzt – kein erneutes Senden
+                            amp_allowed = 16.0
+                            amp_changed = False
                     elif requested_p < current_p and amp_allowed != 6.0:
-                        st.append_debug({"note": "phase-down-temporary-6", "ts": iso_now()})
-                        amp_allowed = 6.0
-                        amp_changed = True
+                        if st.current_limit != 6.0:
+                            st.append_debug({"note": "phase-down-temporary-6", "ts": iso_now()})
+                            amp_allowed = 6.0
+                            amp_changed = True
+                        else:
+                            # bereits 6A gesetzt – kein erneutes Senden
+                            amp_allowed = 6.0
+                            amp_changed = False
                 if amp_changed and (amp_allowed not in [6.0, 16.0]):
                     st.append_debug({"note": "amp-update-blocked-by-hysteresis", "ts": iso_now()})
                     amp_changed = False
@@ -809,12 +940,14 @@ class OCPPManager:
                 target_kwh = st.target_kwh or self.DEFAULT_TARGET_KWH
                 if target_kwh and (st.charged_wh >= target_kwh * 1000.0):
                     st.append_debug({"note": "target-reached-meter", "charged_wh": st.charged_wh, "ts": iso_now()})
+                    cok(f"[{st.log_cp_id}] Lademenge erreicht: {round(st.charged_wh/1000.0, 3)} kWh / {target_kwh} kWh – stoppe Laden")
                     if st.transaction_id:
                         handler = ChargePointHandler(self, st)
                         await handler.send_call("RemoteStopTransaction", {"transactionId": st.transaction_id})
                         st.transaction_id = None
                         st.status = "AvailableRequested"
                         st.transaction_start = None
+                        cok(f"[{st.log_cp_id}] RemoteStopTransaction gesendet → Laden beendet")
                     else:
                         ocpp_phases_value = st.phase_limit or 3
                         handler = ChargePointHandler(self, st)
@@ -823,6 +956,7 @@ class OCPPManager:
                         st.phase_limit = ocpp_phases_value
                         st.status = "AvailableRequested"
                         st.transaction_start = None
+                        cok(f"[{st.log_cp_id}] Ampere/Phase erfolgreich gesetzt: 0.0A / {ocpp_phases_value}P")
             else:
                 st.last_energy_wh = energy_wh
         except Exception:

--- a/FUNCTIONS/ocpp.py
+++ b/FUNCTIONS/ocpp.py
@@ -303,7 +303,7 @@ class OCPPManager:
         self.MIN_CHARGE_DURATION_S = 600
         self.PHASE_CHANGE_CONFIRM_S = 30
         self.residualPower = -300.0
-        self.max_leistung_ha = 0.1
+        self.max_leistung_ha = -100
         self.DEFAULT_TARGET_KWH = 0.0
 
         # NextTrip (PV-Mode 4) Ladezeiten aus DB (ID=4)
@@ -415,7 +415,7 @@ class OCPPManager:
                     try:
                         raw_ha = row4.get('Options')
                         if raw_ha is not None:
-                            self.max_leistung_ha = float(raw_ha)*-1
+                            self.max_leistung_ha = float(raw_ha)*-1000
                     except Exception:
                         pass
                 # update autosync interval
@@ -430,13 +430,14 @@ class OCPPManager:
                     f"{self.wb_phases}, "
                     f"{amp_min_val}, "
                     f"{amp_max_val}, "
+                    f"{self.DEFAULT_TARGET_KWH}, "
+                    f"{self.wb_ladezeit_von}–{self.wb_ladezeit_bis}, "
                     f"{self.AUTO_SYNC_INTERVAL}, "
                     f"{self.MIN_PHASE_DURATION_S}, "
                     f"{self.MIN_CHARGE_DURATION_S}, "
                     f"{self.PHASE_CHANGE_CONFIRM_S}, "
                     f"{self.residualPower}, "
-                    f"{self.DEFAULT_TARGET_KWH}, "
-                    f"NextTrip={self.wb_ladezeit_von}–{self.wb_ladezeit_bis}"
+                    f"{self.max_leistung_ha} "
                 )
 
 
@@ -506,26 +507,31 @@ class OCPPManager:
         phases_to_use = self.wb_phases
 
         current_charge_power = 0
-        # NEU (echter Messwert, konsistent mit HTTP-Endpoint):
+        # Aktuelle Ladepower mit aktuell gesetzten Werten berechnen
         if cp_id and cp_id in self.states:
-            current_charge_power = self._extract_power_w_from_meter_store(cp_id)
-            st = self.states[cp_id]
-            # Fallback auf Schätzung wenn noch keine MeterValues vorliegen
-            if current_charge_power == 0.0 and st.current_limit and st.phase_limit:
-                if st.status in ["Charging", "ChargingRequested"]:
-                    current_charge_power = self.get_current_power(cp_id)
+            current_charge_power = self.get_current_power(cp_id)  # A × P × U(gemessen), Fallback 230V
 
         # Inverter-Werte verrechnen
-        # Wert "-inf" wäre unendlich = keine Begrenzung ##WIGGAL
+        # Hausakku Ladebegrenzung, rechnen -0.1kW = keine Begrenzung
         if self.max_leistung_ha > 0:
             batterie_anteil = self.Batteriebezug
         else:
             batterie_anteil = max(self.max_leistung_ha, min(self.Batteriebezug, 0.0)) ##WIGGAL
+
+        # batterie_antei darf nicht größer 0 sein
+        if batterie_anteil > 0: batterie_anteil = 0
+
         self.hausverbrauch = max(0.0, self.Produktion + self.Batteriebezug + self.Netzbezug - current_charge_power)
         ueberschuss = int(max(0.0, (self.Produktion - self.hausverbrauch + batterie_anteil - self.residualPower)))
-        print("==>>>WIGGAL", self.max_leistung_ha, batterie_anteil)
+        #print("==>>>WIGGAL", self.max_leistung_ha, batterie_anteil)
 
-        cinfo(f"[{'..' + cp_id[-4:]}] Ladeberechnung: PV={self.Produktion} W, Akku={self.Batteriebezug} W, Netz={self.Netzbezug} W, Haus={self.hausverbrauch} W, CP={current_charge_power} W, Überschuss={ueberschuss} W")
+        cinfo(f"[{'..' + cp_id[-4:]}] Ladeberechnung: "
+            f"PV={self.Produktion:.0f} W, "
+            f"Akku={self.Batteriebezug:.0f} W, "
+            f"Netz={self.Netzbezug:.0f} W, "
+            f"Haus={self.hausverbrauch:.0f} W, "
+            f"CP={current_charge_power:.0f} W, "
+            f"Überschuss={ueberschuss:.0f} W")
 
         if float(self.wb_pv_mode) in (1.0, 2.0):
             # Standard: Im Modus 1.0 (Nur PV) darf die Ladung auf 0 abfallen
@@ -612,13 +618,14 @@ class OCPPManager:
         st = self.states.get(cp_id)
         if not st:
             return 0.0
+
         try:
             curr = float(st.current_limit or 0.0)
             phases = int(st.phase_limit or 0)
-            return curr * phases * 230.0
+            voltage = self._get_average_voltage(cp_id)  # statt fix 230V
+            return curr * phases * voltage
         except Exception:
             return 0.0
-
     # ----------------------------
     # Apply-Wallbox-Settings (Hauptlogik)
     # ----------------------------
@@ -674,7 +681,8 @@ class OCPPManager:
 
             charged_wh = round(st.charged_wh,1) or 0.0
             # verbose info for current state including PV mode and charged Wh
-            cinfo(f"[{st.log_cp_id}] PV-Mode={pv_mode}, PV-Steuerung={is_pv_controlled}, Wunsch: {amp_desired}A/{requested_phase}P, Aktuell: {st.current_limit}A/{st.phase_limit}P, Geladen: {charged_wh}Wh")
+            limit_str = f"{st.current_limit}A/{st.phase_limit}P" if st.current_limit is not None else "unbekannt"
+            cinfo(f"[{st.log_cp_id}] PV-Mode={pv_mode}, PV-Steuerung={is_pv_controlled}, Wunsch: {amp_desired}A/{requested_phase}P, Aktuell: {limit_str}, Geladen: {charged_wh}Wh")
 
             # PHASE HYSTERESE: nur wenn Änderung, nicht initial, Laden > 0 gewünscht
             # UND automatische Phasenwahl aktiv (wb_phases == "0")
@@ -694,6 +702,8 @@ class OCPPManager:
                         st.phase_candidate = None
                         st.append_debug({"note": "phase-hysteresis-confirmed", "requested": requested_phase, "ts": iso_now()})
                     else:
+                        remaining_s = int(self.PHASE_CHANGE_CONFIRM_S - elapsed)
+                        cinfo(f"[{st.log_cp_id}] Phasenwechsel-Hysterese aktiv – noch {remaining_s}s warten.")
                         phase_changed = False
             else:
                 # cleanup if not relevant
@@ -742,7 +752,7 @@ class OCPPManager:
                     cdebug(f"[{st.log_cp_id}] Stop-Guard übersprungen – Fahrzeug in SuspendedEV")
                 else:
                     can_stop = True
-                    if is_pv_controlled and st.transaction_start:
+                    if is_pv_controlled and st.transaction_start and st.transaction_id:
                         duration = (datetime.now() - st.transaction_start).total_seconds()
                         if duration < self.MIN_CHARGE_DURATION_S:
                             can_stop = False
@@ -754,16 +764,38 @@ class OCPPManager:
 
                 if not can_stop:
                     amp_allowed = amp_min or self.wb_amp_min
+                    st.stop_candidate = None  # Stop-Guard aktiv → Hysterese zurücksetzen
                     st.append_debug({"note": "stop-guard-applied", "amp": amp_allowed, "ts": iso_now()})
                 else:
-                    if active_tx_id:
-                        handler = ChargePointHandler(self, st)
-                        await handler.send_call("RemoteStopTransaction", {"transactionId": active_tx_id})
-                        st.transaction_id = None
-                        st.status = "AvailableRequested"
-                        st.transaction_start = None
-                        st.append_debug({"note": "remote-stop-sent", "ts": iso_now()})
+                    if active_tx_id and amp_allowed == 0.0:
+                        # Stop-Hysterese: kurze Unterschreitungen abfangen
+                        now = datetime.now()
+                        if st.stop_candidate is None:
+                            st.stop_candidate = now
+                            amp_allowed = amp_min or self.wb_amp_min
+                            cinfo(f"[{st.log_cp_id}] Stop-Hysterese gestartet – warte {self.PHASE_CHANGE_CONFIRM_S}s vor Stopp")
+                            st.append_debug({"note": "stop-hysteresis-start", "ts": iso_now()})
+                        else:
+                            elapsed = (now - st.stop_candidate).total_seconds()
+                            if elapsed < self.PHASE_CHANGE_CONFIRM_S:
+                                remaining_s = int(self.PHASE_CHANGE_CONFIRM_S - elapsed)
+                                amp_allowed = amp_min or self.wb_amp_min
+                                cinfo(f"[{st.log_cp_id}] Stop-Hysterese aktiv – noch {remaining_s}s warten vor Stopp")
+                                st.append_debug({"note": "stop-hysteresis-wait", "remaining_s": remaining_s, "ts": iso_now()})
+                            else:
+                                st.stop_candidate = None
+                                cinfo(f"[{st.log_cp_id}] Stop-Hysterese bestätigt – stoppe Laden")
+                                handler = ChargePointHandler(self, st)
+                                await handler.send_call("RemoteStopTransaction", {"transactionId": active_tx_id})
+                                st.transaction_id = None
+                                st.status = "AvailableRequested"
+                                st.transaction_start = None
+                                st.append_debug({"note": "remote-stop-sent", "ts": iso_now()})
+                    elif active_tx_id:
+                        # amp_allowed > 0 → Laden gewünscht, Stop-Kandidat zurücksetzen
+                        st.stop_candidate = None
                     elif status not in ["Available", "AvailableRequested"]:
+                        st.stop_candidate = None
                         # Nur auf Available setzen wenn Fahrzeug NICHT angesteckt ist
                         physically_plugged = status in ["SuspendedEVSE", "Preparing", "Finishing", "SuspendedEV"]
                         if not physically_plugged:
@@ -784,7 +816,7 @@ class OCPPManager:
             # ---------------------------
             # AMPERE-ANPASSUNG WÄHREND DER PHASEN-HYSTERESE (wie Original)
             # ---------------------------
-            amp_changed = (st.current_limit != amp_allowed)
+            amp_changed = abs((st.current_limit or 0.0) - amp_allowed) > 0.5
             candidate = st.phase_candidate
             if candidate:
                 requested_p = candidate.get('requested')

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,9 @@ und eine Produktion über der AC-Ausgangsleistungsgrenze des WR als DC in die Ba
 - [Home Assistant Add-on](https://github.com/roethigj/ha_addons/tree/main/gen24_ladesteuerung) erstellt von [@roethigj](https://github.com/roethigj).  
 
 ![new](pics/new.png)  
+Ab Version: **0.42.0**  
+- 🚘 Steuerung des Wattpiloten, nun auch mit NextTrip.  
+
 Ab Version: **0.41.7**  
 - Es ist nun auch eine Reduzierung der Ladeleistung in Abhängigkeit der höchsten Zellspannung möglich.  
 
@@ -159,22 +162,3 @@ Konsolidierung der Dokumentation, Hilfen und [Wiki](https://wiggal.github.io/GEN
 Ab Version: **0.30.0**  
 Speicherung der Prognosedaten in `weatherData.sqlite`, Berechnung der Prognose mit gespeicherten Werten.  
 Mit dem verlinkten  `ForecastMgr` können die Prognosedaten gesichtet und gelöscht werden.  
-Ab Version: **0.29.0**  
-Zur Akkuschonung kann der Akku bei entprechender Prognose auch nur bis 80% geladen werden.  
-Vorbereitung des DynamicPriceCheck auf viertelstündliche Strompreise.  
-Ab Version: **0.28.1**  
-Neues Prognoseskripte Akkudoktor__WeatherData.py für https://api.akkudoktor.net/ von @tz8  
-**ACHTUNG:** Umfangreiche Änderungen in CONFIG/weather_priv.ini nötig!!  
-Ab Version: **0.28.0**  
-**ACHTUNG:** Die Prognoseskripte wurden ins Verzeichnis FORECAST verschoben.  
-**Cronjobs müssen angepasst werden!!** (siehe Cortabeinträge Wetterdienste).  
-Ab Version: **0.26.9**  
-Diagramm zur Darstellung der dynamischen Strompreise.  
-Ab Version: **0.26.8**  
-Beschreibung zu Auswertungen mit Grafana inklusive fertige Dashboards von @Manniene  
-Ab Version: **0.26.1**  
-Dynamischer Strompreis: Akku laden bei günstigen Strompreisen in Tabelle ENTLadeStrg eintragen durch DynamicPriceCheck.py.  
-Ab Version: **0.25.1**  
-Prognosebegrenzung auf Höchstwerte der historischen Produktion.  
-Ab Version: **0.25.0**  
-Zwangsladung durch Eintragen von negativen kW in die Tabelle ENTLadeStrg  

--- a/docs/WIKI/Wallbox.html
+++ b/docs/WIKI/Wallbox.html
@@ -49,8 +49,9 @@ zur Unterscheidung der im WebUI eingestellten aber noch nicht gesicherten Werte.
         <ul>
             <li>Aus =&gt; Laden wird/ist gestoppt</li>
             <li>PV =&gt; Reines Überschussladen</li>
-            <li>MIN+PV =&gt; Mit der kleinsten eingestellte Lademenge wird immer geladen.<br>Ist der PV-Überschuss größer, wird mit diesem geladen.</li>
-            <li>MAX =&gt; Es wird immer mit der größten eingestellten Lademenge geladen.<br></li>
+            <li>MIN+PV =&gt; Mit der kleinsten eingestellte Ladeleistung wird immer geladen.<br>Ist der PV-Überschuss größer, wird mit diesem geladen.</li>
+            <li>MAX =&gt; Es wird immer mit der größten eingestellten Ladeleistung geladen.<br></li>
+            <li>NextTrip =&gt; Im eingestellten Zeitraum wird immer mit der größten eingestellten Ladeleistung geladen, bis Lademenge erreicht ist.<br></li>
         </ul>
     </li>
     <li><span class="label-inline">Phasen (DB=0):<br></span>
@@ -131,6 +132,11 @@ zur Unterscheidung der im WebUI eingestellten aber noch nicht gesicherten Werte.
                 <span class="label-inline">(+)300 =&gt; es sollen 300 Watt im System verbleiben, die entweder in den Akku oder ins Netz fließen.</span><br>
                 <span class="label-inline">- 300 &nbsp; =&gt; es sollen 300 Watt mehr geladen werden, als im System vorhanden sind, die entweder aus dem Akku oder aus dem Netz gezogen werden.</span>
             </li>
+        </ul>
+    </li>
+    <li><span class="label-inline">Ladebegr. Hausakku(kW) (DB=0.8):</span>
+        <ul>
+            <li><span class="label-inline">Hiermit kann die Ladeleistung des Hausakkus ungefähr auf die eingestellten kW begrenzt werden, falls sie höher wäre.</span></li>
         </ul>
     </li>
 </ul>

--- a/docs/WIKI/Wallbox.html
+++ b/docs/WIKI/Wallbox.html
@@ -1,238 +1,154 @@
 <!DOCTYPE html>
-<html>
-  <head>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-    <meta name="viewport" content="width=device-width">
+<html lang="de-DE">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Wallbox</title>
-  </head>
-  <body lang="de-DE">
-    <!--HIERZURUECK--><br>
-    <p> <font style="font-size: 24pt"><b>TAB --&gt;&gt; Wallbox </b></font></p>
-    <p><strong>Stand: 04.01.2026<br>
-      </strong></p>
-    <p>Das Tool stellt einen OCPP-Server bereit, zu dem eine Wallbox
-      eine Verbindung als Client herstellt.<br>
-      Einstellungen für Fronius Wattpilot in der App siehe
-      Clientkonfiguration.<br>
-      <strong></strong></p>
-    <p><strong>Programmfunktionen:</strong></p>
-    <ul>
-      <li>Ladung mit fester Leistung</li>
-      <li>PV-Überschussladung<br>
-      </li>
-    </ul>
-    <strong>Funktionsweise:</strong>
-    <ul>
-      <li> Es wird ein OCPP-Server gestartet, zu dem eine Wallbox
-        (bisher Wattpilot) Verbindung aufnimmt.&nbsp;</li>
-      <li>Über die WebUI kann der OCPP-Server gestartet und gestoppt
-        werden, sie stellt auch den Status des OCPP-Server dar.</li>
-      <li> Der OCPP-Server kann auch automatisch durch die Einstellung <font
-          size="+1"> <code>wallboxsteuerung = 1</code></font> in
-        CONFIG/default_priv.ini gestartet werden.<br>
-      </li>
-      <li>Über die WebUI können die Ladeoptionen eingestellt und in die
-        DB CONFIG/Prog_Steuerung.sqlite gespeichert werden.</li>
-      <li>Der OCPP-Server liest die Optionen in dem eingestellten
-        Zeitintervall (<span class="label-inline">
-          <meta http-equiv="content-type" content="text/html;
-            charset=UTF-8">
-          <span class="label-inline">Wallboxaktualisierung) aus der DB
-            und sendet sie wenn nötig an die Wallbox.</span></span></li>
-      <li><span class="label-inline"><span class="label-inline">Das <b>Logfile</b>
-            <b>ocpp.log</b> liegt in /tmp und damit im Arbeitsspeicher,
-            damit die Speicherkarte eines Raspberry nicht so oft
-            beschrieben wird. <br>
-          </span></span></li>
-    </ul>
-    <p> <strong>Optionen:<br>
-      </strong></p>
-    Die numerischen Werte in Klammern sind die Einstellungen aus der DB,<br>
-    zur Unterscheidung der im WebUI eingestellten aber noch nicht
-    gesicherten Werte.<br>
-    <ul>
-      <li>PV-Modus (DB=0): <strong><br>
-        </strong>
+    <style type="text/css">
+        body { font-family: sans-serif; line-height: 1.5; padding: 20px; }
+        .c1 { font-size: 24pt; font-weight: bold; }
+        .c2 { font-size: 120%; font-family: monospace; }
+        .label-inline { font-weight: normal; }
+        ul { margin-bottom: 10px; }
+    </style>
+</head>
+<body lang="de-DE">
+<!--HIERZURUECK--><br>
+
+<p><span class="c1">TAB --&gt;&gt; Wallbox</span></p>
+
+<p><strong>Stand: 17.04.2026<br></strong></p>
+
+<p>
+    Das Tool stellt einen OCPP-Server bereit, zu dem eine Wallbox eine Verbindung als Client herstellt.<br>
+    Einstellungen für Fronius Wattpilot in der App siehe Clientkonfiguration.<br>
+</p>
+
+<p><strong>Programmfunktionen:</strong></p>
+<ul>
+    <li>Ladung mit fester Leistung</li>
+    <li>PV-Überschussladung<br></li>
+</ul>
+
+<strong>Funktionsweise:</strong>
+<ul>
+    <li>Es wird ein OCPP-Server gestartet, zu dem eine Wallbox (bisher Wattpilot) Verbindung aufnimmt.</li>
+    <li>Über die WebUI kann der OCPP-Server gestartet und gestoppt werden, sie stellt auch den Status des OCPP-Server dar.</li>
+    <li>Der OCPP-Server kann auch automatisch durch die Einstellung <span class="c2"><code>wallboxsteuerung = 1</code></span> in CONFIG/default_priv.ini gestartet werden.<br></li>
+    <li>Über die WebUI können die Ladeoptionen eingestellt und in die DB CONFIG/Prog_Steuerung.sqlite gespeichert werden.</li>
+    <li>Der OCPP-Server liest die Optionen in dem eingestellten Zeitintervall (<span class="label-inline">Wallboxaktualisierung</span>) aus der DB und sendet sie wenn nötig an die Wallbox.</li>
+    <li><span class="label-inline">Das <b>Logfile</b> <b>ocpp.log</b> liegt in /tmp und damit im Arbeitsspeicher, damit die Speicherkarte eines Raspberry nicht so oft beschrieben wird.<br></span></li>
+</ul>
+
+<p><strong>Optionen:<br></strong></p>
+Die numerischen Werte in Klammern sind die Einstellungen aus der DB,<br>
+zur Unterscheidung der im WebUI eingestellten aber noch nicht gesicherten Werte.<br>
+
+<ul>
+    <li>PV-Modus (DB=0):
         <ul>
-          <li>Aus =&gt; Laden wird/ist gestoppt</li>
-          <li>PV =&gt;&nbsp; Reines Überschussladen</li>
-          <li>MIN+PV =&gt; Mit der kleinsten eingestellte Lademenge wird
-            immer&nbsp; geladen. <br>
-            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-
-
-
-            Ist der PV-Überschuss größer, wird mit diesem geladen.</li>
-          <li>MAX =&gt; Es wird immer mit der größten eingestellten
-            Lademenge geladen.<br>
-          </li>
+            <li>Aus =&gt; Laden wird/ist gestoppt</li>
+            <li>PV =&gt; Reines Überschussladen</li>
+            <li>MIN+PV =&gt; Mit der kleinsten eingestellte Lademenge wird immer geladen.<br>Ist der PV-Überschuss größer, wird mit diesem geladen.</li>
+            <li>MAX =&gt; Es wird immer mit der größten eingestellten Lademenge geladen.<br></li>
         </ul>
-      </li>
-      <li>
-        <div class="row">
-          <meta http-equiv="content-type" content="text/html;
-            charset=UTF-8">
-          <span class="label-inline">Phasen (DB=0):<br>
-          </span>
-          <ul>
-            <li>Auto =&gt; Die Phase wird automatisch je nach PV-Modus
-              gewählt.</li>
-            <li>1 Phase =&lt; Nur mit Phase 1 laden. <br>
+    </li>
+    <li><span class="label-inline">Phasen (DB=0):<br></span>
+        <ul>
+            <li>Auto =&gt; Die Phase wird automatisch je nach PV-Modus gewählt.</li>
+            <li>1 Phase =&lt; Nur mit Phase 1 laden.<br></li>
+            <li>3 Phase =&lt; Nur mit Phase 3 laden.<br></li>
+        </ul>
+    </li>
+    <li><span class="label-inline">Stromstärke MIN (DB=6):<br></span>
+        <ul>
+            <li>Mit einer geringeren Stromstärke wird in den PV-Modi nicht geladen.<br></li>
+        </ul>
+    </li>
+    <li><span class="label-inline">Stromstärke MAX (DB=16):<br></span>
+        <ul>
+            <li>Mit einer höheren Stromstärke wird nicht geladen.</li>
+        </ul>
+    </li>
+    <li><span class="label-inline">Lademenge (kWh) (DB=0):</span>
+        <ul>
+            <li><span class="label-inline">Hier kann eine feste Lademenge eingestellt werden, ist sie erreicht, wird das Laden beendet.</span></li>
+        </ul>
+    </li>
+</ul>
+
+<strong>Next Trip Optionen:<br></strong>
+<ul>
+    <li><span class="label-inline">Ladezeit-von (DB=12:30):</span>
+        <ul>
+            <li><span class="label-inline">Anfangszeitpunkt für NextTrip.<br></span></li>
+        </ul>
+    </li>
+    <li><span class="label-inline">Ladezeit-bis (DB=05:00):</span>
+        <ul>
+            <li><span class="label-inline">Endzeitpunkt für NextTrip.</span></li>
+        </ul>
+    </li>
+    <li><span class="label-inline">Strompreis (€) (DB=0.3):</span>
+        <ul>
+            <li><span class="label-inline">Strompreis zur Berechnung der Ladezeiträume für die Option NextTrip (0=Dynamischer Strompreis).</span></li>
+        </ul>
+    </li>
+    <li><span class="label-inline">Einspeisevergütung (€) (DB=0.07):</span>
+        <ul>
+            <li><span class="label-inline">Einspeisevergütung zur Berechnung der Ladezeiträume für die Option NextTrip.</span></li>
+        </ul>
+    </li>
+</ul>
+
+<strong>Erweiterte Optionen:<br></strong>
+<ul>
+    <li><span class="label-inline">Wallboxaktualisierung(s) (DB=20):</span>
+        <ul>
+            <li><span class="label-inline">In diesem Intervall werden die errechneten Steuerungswerte an die Wallbox gesendet.</span></li>
+            <li><span class="label-inline">Phasen-Delay =&gt;<br></span></li>
+        </ul>
+    </li>
+    <li><span class="label-inline">Phasen-Intervall(s) (DB=600):</span>
+        <ul>
+            <li><span class="label-inline">Mindestladezeit auf einer Phase, bevor sie wieder umgeschaltet werden darf.</span><br></li>
+        </ul>
+    </li>
+    <li><span class="label-inline">Mindestladezeit(s) (DB=600):</span>
+        <ul>
+            <li><span class="label-inline">Mindestladezeit, bevor die Ladung wieder gestoppt werden darf.</span></li>
+        </ul>
+    </li>
+    <li><span class="label-inline">Phasen-Delay(s) (DB=300):</span>
+        <ul>
+            <li><span class="label-inline">Die Bedingungen für einen Phasenwechsel müssen für diesen Zeitraum vorliegen.</span></li>
+        </ul>
+    </li>
+    <li><span class="label-inline">Verbleibende Leistung(W) (DB=300):</span>
+        <ul>
+            <li><span class="label-inline">Legt den Sollwert für die im System verbleibende Energie fest.</span><br>
+                <span class="label-inline">Es ist dabei zu beachten, dass nur in ganzen Ampere geschaltet werden kann, und die Werte nicht genau erreicht werden können, zum Beispiel:</span><br>
+                <span class="label-inline">(+)300 =&gt; es sollen 300 Watt im System verbleiben, die entweder in den Akku oder ins Netz fließen.</span><br>
+                <span class="label-inline">- 300 &nbsp; =&gt; es sollen 300 Watt mehr geladen werden, als im System vorhanden sind, die entweder aus dem Akku oder aus dem Netz gezogen werden.</span>
             </li>
-            <li>3 Phase =&lt; Nur mit Phase 3 laden. <br>
-            </li>
-          </ul>
-        </div>
-      </li>
-      <li><span class="label-inline"><span class="label-inline"><span
-              class="label-inline">Stromstärke MIN (DB=6):<br>
-            </span></span></span>
-        <ul>
-          <li>Mit einer geringeren Stromstärke wird in den PV-Modi nicht
-            geladen.<br>
-          </li>
         </ul>
-      </li>
-      <li><span class="label-inline"><span class="label-inline"><span
-              class="label-inline"><span class="label-inline"><span
-                  class="label-inline">Stromstärke MAX (DB=16):<br>
-                </span></span></span></span></span>
-        <ul>
-          <li>Mit einer höheren Stromstärke wird nicht geladen.</li>
-        </ul>
-      </li>
-    </ul>
-    <summary>
-      <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-      <strong>Erweiterte Optionen:<br>
-      </strong>
-      <ul>
-        <li><span class="label-inline">
-            <meta http-equiv="content-type" content="text/html;
-              charset=UTF-8">
-          </span>Timing Einstellungen<span class="label-inline"></span><span
-            class="label-inline"><span class="label-inline"> (s =
-              Sekunden) <br>
-            </span></span>
-          <ul>
-            <li><span class="label-inline">
-                <meta http-equiv="content-type" content="text/html;
-                  charset=UTF-8">
-                <span class="label-inline">Wallboxaktualisierung =&gt;
-                  In diesem Intervall werden die errechneten
-                  Steuerungswerte an die Wallbox gesendet.</span></span></li>
-            <li><span class="label-inline"><span class="label-inline"><span
-                    class="label-inline"><span class="label-inline"></span></span></span></span><span
-                class="label-inline"><span class="label-inline"><span
-                    class="label-inline"><span class="label-inline"><span
-                        class="label-inline">Phasen-Intervall</span>
-                      <meta http-equiv="content-type"
-                        content="text/html; charset=UTF-8">
-                      =&gt; Mindestladezeit auf einer Phase, bevor sie
-                      wieder umgeschaltet werden darf.</span></span></span></span></li>
-            <li><span class="label-inline"><span class="label-inline"><span
-                    class="label-inline"><span class="label-inline"><span
-                        class="label-inline"><span class="label-inline">Mindestladezeit&nbsp;
+    </li>
+</ul>
 
-
-
-                          =&gt; </span></span></span></span></span></span><span
-                class="label-inline"><span class="label-inline"><span
-                    class="label-inline"><span class="label-inline"><span
-                        class="label-inline"><span class="label-inline"><span
-                            class="label-inline"><span
-                              class="label-inline"><span
-                                class="label-inline"><span
-                                  class="label-inline">Mindestladezeit,
-                                  bevor die Ladung wieder gestoppt
-                                  werden darf.</span></span></span></span></span></span></span></span></span></span></li>
-            <li><span class="label-inline"><span class="label-inline"><span
-                    class="label-inline"><span class="label-inline"><span
-                        class="label-inline"><span class="label-inline"><span
-                            class="label-inline"><span
-                              class="label-inline"><span
-                                class="label-inline"><span
-                                  class="label-inline"><span
-                                    class="label-inline"><span
-                                      class="label-inline"><span
-                                        class="label-inline">
-                                        <meta http-equiv="content-type"
-                                          content="text/html;
-                                          charset=UTF-8">
-                                        <span class="label-inline">Phasen-Delay</span></span>
-                                      =&gt; Die Bedingungen für einen
-                                      Phasenwechsel müssen für diesen
-                                      Zeitraum vorliegen. <br>
-                                    </span></span></span></span></span></span></span></span></span></span></span></span></li>
-          </ul>
-        </li>
-      </ul>
-    </summary>
-    <ul>
-      <li>Sonstige Zielwerte<br>
+<hr width="100%" size="2">
+<strong>Clientkonfiguration =&gt; Wattpilot App:<br></strong>
+<ul>
+    <li>In der Wattpilot App ist folgendes einzustellen, damit sich der Wattpilot mit dem OCPP-Server verbindet.<br>
         <ul>
-          <li><span class="label-inline">
-              <meta http-equiv="content-type" content="text/html;
-                charset=UTF-8">
-              <span class="label-inline">Verbleibende Leistung =&gt;
-                Legt den Sollwert für die im System verbleibende Energie
-                fest.<br>
-              </span></span><span class="label-inline"><span
-                class="label-inline">Es ist dabei zu beachten, dass nur
-                in ganzen Ampere geschaltet werden kann, und die Werte
-                nicht genau erreicht werden können, zum Beispiel:</span></span><br>
-            <span class="label-inline"><span class="label-inline"></span></span><span
-              class="label-inline"><span class="label-inline">(+)300
-                =&gt; es sollen 300 Watt im System verbleiben, die
-                entweder in den Akku oder ins Netz fließen.</span></span><br>
-            <span class="label-inline"><span class="label-inline"><span
-                  class="label-inline"><span class="label-inline">- 300
-                    &nbsp; =&gt; es sollen 300 Watt mehr geladen werden,
-                    als im System vorhanden sind, die entweder aus dem
-                    Akku oder aus dem Netz gezogen werden.</span></span></span></span></li>
-          <li><span class="label-inline"><span class="label-inline"><span
-                  class="label-inline"><span class="label-inline"><span
-                      class="label-inline"><span class="label-inline">Lademenge
-
-
-
-                        (kWh) =&gt; Hier kann eine feste Lademenge
-                        eingestellt werden, ist sie erreicht, wird das
-                        Laden beendet.<br>
-                      </span></span></span></span></span></span></li>
+            <li>Modus: Eco Mode und Next Trip Mode müssen <b>AUS</b> sein.<br></li>
+            <li>Einstellungen, Fahrzeug PHASENUMSCHALTUNG: <b>Automatisch</b></li>
+            <li>Internet, OCPP 1.6J =&gt; <b>aktiviert</b></li>
+            <li>Auf das Klippboard klicken und folgendes eintragen (xxx = IP-Adresse des OCPP-Servers) :<br>
+                <code>ws://xxx.xxx.xxx.xx:8887</code><br></li>
+            <li>Füge SN (Seriennummer) zur URL =&gt; <b>aktiviert</b></li>
         </ul>
-      </li>
-    </ul>
-    <ul>
-    </ul>
-    <p><strong>Clientkonfiguration =&gt; </strong><strong>Wattpilot
-        App:<br>
-      </strong></p>
-    <ul>
-      <li>In der Wattpilot App ist folgendes einzustellen, damit sich
-        der Wattpilot mit dem OCPP-Server verbindet.<br>
-        <ul>
-          <li> Modus: Eco Mode und Next Tripp Mode müssen <b>AUS</b>
-            sein.<br>
-          </li>
-        </ul>
-        <ul>
-          <li> Einstellungen, Fahrzeug PHASENUMSCHALTUNG: <b>Automatisch</b></li>
-        </ul>
-        <ul>
-          <li> Internet, OCPP 1.6J =&gt; <b>aktiviert</b></li>
-        </ul>
-        <ul>
-          <li> Auf das Klippboard klicken und folgendes eintragen (xxx =
-            IP-Adresse des OCPP-Servers) :<br>
-            ws://xxx.xxx.xxx.xx:8887 <br>
-          </li>
-        </ul>
-        <ul>
-          <li> Füge SN (Seriennummer) zur URL =&gt; <b>aktiviert</b></li>
-        </ul>
-        <br>
-      </li>
-    </ul>
-  </body>
+    </li>
+</ul>
+</body>
 </html>
+

--- a/docs/WIKI/Wallbox.html
+++ b/docs/WIKI/Wallbox.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <html lang="de-DE">
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width">
     <title>Wallbox</title>
-    <style type="text/css">
-        body { font-family: sans-serif; line-height: 1.5; padding: 20px; }
-        .c1 { font-size: 24pt; font-weight: bold; }
-        .c2 { font-size: 120%; font-family: monospace; }
-        .label-inline { font-weight: normal; }
-        ul { margin-bottom: 10px; }
+    <style>
+        @media (max-width: 600px) {
+        table, th, td {
+            font-size: 90% !important;
+        }
+        }
     </style>
 </head>
 <body lang="de-DE">
@@ -17,7 +17,7 @@
 
 <p><span class="c1">TAB --&gt;&gt; Wallbox</span></p>
 
-<p><strong>Stand: 17.04.2026<br></strong></p>
+<p><strong>Stand: 20.04.2026<br></strong></p>
 
 <p>
     Das Tool stellt einen OCPP-Server bereit, zu dem eine Wallbox eine Verbindung als Client herstellt.<br>
@@ -136,7 +136,8 @@ zur Unterscheidung der im WebUI eingestellten aber noch nicht gesicherten Werte.
     </li>
     <li><span class="label-inline">Ladebegr. Hausakku(kW) (DB=0.8):</span>
         <ul>
-            <li><span class="label-inline">Hiermit kann die Ladeleistung des Hausakkus ungefähr auf die eingestellten kW begrenzt werden, falls sie höher wäre.</span></li>
+            <li><span class="label-inline">Hiermit kann die Ladeleistung des Hausakkus ungefähr auf die eingestellten kW begrenzt werden, falls sie größer wäre.<br>
+            Bei -0.1 ist die Begrenzung abgeschaltet.</span></li>
         </ul>
     </li>
 </ul>

--- a/docs/WIKI/config.html
+++ b/docs/WIKI/config.html
@@ -285,127 +285,136 @@ Fast-forward
 <tr><td colspan="2"><input type="hidden" name="Zeile[25]" value='' ></td></tr>
 <tr><td colspan="2"><input type="hidden" name="Zeile[26]" value='' ></td></tr>
 <tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[27]" value='[forecast.solar]' >[forecast.solar]</td></tr>
+<tr class="comment"><td colspan="2">; Wenn die Prognosekurve zur Produktionskurve generell verschoben ist, kann die Zeit hiermit um X Minuten verschoben werden<br>; Positive Werte = früher (nach links),negative = später (nach rechts). </td></tr>
+<tr><td class="variablenname">offset_minuten</td>
+<td><input type="text" name="Zeile[29][1]" value="0" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Wenn api_key nicht &quot;kein&quot; ist, wird er für die Prognoseabfrage verwendet. </td></tr>
 <tr><td class="variablenname">api_key</td>
-<td><input type="text" name="Zeile[29][1]" value="kein" readonly></td></tr>
+<td><input type="text" name="Zeile[31][1]" value="kein" readonly></td></tr>
 <tr class="comment"><td colspan="2">; wenn ein API key vorhanden ist, können die Forecasts mit aktuellen Ertragswerten des Tages (aus der DB) verbessert werden.<br>; &quot;ja&quot; nutzt diese Funktion der API, &quot;nein&quot; nicht.<br>; Siehe https://doc.forecast.solar/actual </td></tr>
 <tr><td class="variablenname">forecastactual</td>
-<td><input type="text" name="Zeile[31][1]" value="nein" readonly></td></tr>
+<td><input type="text" name="Zeile[33][1]" value="nein" readonly></td></tr>
 <tr class="comment"><td colspan="2">; wenn &quot;damping&quot; eingesetzt werden soll, hier die entsprechenden Werte einstellen. &quot;0,0&quot; ist Standardwert (kein Damping)<br>; 0,0 bedeutet kein Damping, 0.25,0.75 bedeutet etwas damping am Morgen, hohes Damping am Nachmittag.<br>; beide Werte müssen zwischen 0 und 1 sein<br>; Siehe https://doc.forecast.solar/damping </td></tr>
 <tr><td class="variablenname">forecastdamping</td>
-<td><input type="text" name="Zeile[33][1]" value="0,0" readonly></td></tr>
+<td><input type="text" name="Zeile[35][1]" value="0,0" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Wenn ein api_pers_plus vorhanden ist (api_pers_plus = ja) können zwei Ausrichtungen in einer Abfrage behandelt werden. </td></tr>
 <tr><td class="variablenname">api_pers_plus</td>
-<td><input type="text" name="Zeile[35][1]" value="nein" readonly></td></tr>
+<td><input type="text" name="Zeile[37][1]" value="nein" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Gewicht ermöglicht eine höhere Gewichtung des Wetterdienstes (je größer der Wert, umso größer das Gewicht)<br>; Gewicht = 0; die Prognose wird nicht zur Berechnung der Durchschnittsprognose verwendet. </td></tr>
 <tr><td class="variablenname">Gewicht</td>
-<td><input type="text" name="Zeile[37][1]" value="1" readonly></td></tr>
-<tr><td colspan="2"><input type="hidden" name="Zeile[38]" value='' ></td></tr>
-<tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[39]" value='[akkudoktor]' >[akkudoktor]</td></tr>
-<tr class="comment"><td colspan="2">; spezifische Werte für die API von Andreas Schmitz, dem Akkudoktor https://www.youtube.com/@Akkudoktor<br>; weitere Infos unter https://api.akkudoktor.net/<br>; der Zellkoeffizient wird für die Berechnung der Verluste im Kontext herrschender Temperaturen genutzt </td></tr>
+<td><input type="text" name="Zeile[39][1]" value="1" readonly></td></tr>
+<tr><td colspan="2"><input type="hidden" name="Zeile[40]" value='' ></td></tr>
+<tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[41]" value='[akkudoktor]' >[akkudoktor]</td></tr>
+<tr class="comment"><td colspan="2">; spezifische Werte für die API von Andreas Schmitz, dem Akkudoktor https://www.youtube.com/@Akkudoktor<br>; weitere Infos unter https://api.akkudoktor.net/<br>; Wenn die Prognosekurve zur Produktionskurve generell verschoben ist, kann die Zeit hiermit um X Minuten verschoben werden<br>; Positive Werte = früher (nach links),negative = später (nach rechts). </td></tr>
+<tr><td class="variablenname">offset_minuten</td>
+<td><input type="text" name="Zeile[43][1]" value="0" readonly></td></tr>
+<tr class="comment"><td colspan="2">; der Zellkoeffizient wird für die Berechnung der Verluste im Kontext herrschender Temperaturen genutzt </td></tr>
 <tr><td class="variablenname">cellco</td>
-<td><input type="text" name="Zeile[41][1]" value="-0.4" readonly></td></tr>
+<td><input type="text" name="Zeile[45][1]" value="-0.4" readonly></td></tr>
 <tr class="comment"><td colspan="2">; albedo ist der Reflexionsgrad des Untergrunds, auf dem die Zellen montiert sind. Siehe https://pv-navi.de/pv-navi-abc/albedo/ </td></tr>
 <tr><td class="variablenname">albedo</td>
-<td><input type="text" name="Zeile[43][1]" value="0.2" readonly></td></tr>
+<td><input type="text" name="Zeile[47][1]" value="0.2" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Gesamtleistung des Wechselrichters </td></tr>
 <tr><td class="variablenname">powerInverter</td>
-<td><input type="text" name="Zeile[45][1]" value="8000" readonly></td></tr>
+<td><input type="text" name="Zeile[49][1]" value="8000" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Effizienz des Wechselrichter </td></tr>
 <tr><td class="variablenname">inverterEfficiency</td>
-<td><input type="text" name="Zeile[47][1]" value="1" readonly></td></tr>
+<td><input type="text" name="Zeile[51][1]" value="1" readonly></td></tr>
 <tr class="comment"><td colspan="2">; spezifische Werte für eventuellen 2. String: </td></tr>
 <tr><td class="variablenname">cellco2</td>
-<td><input type="text" name="Zeile[49][1]" value="-0.4" readonly></td></tr>
+<td><input type="text" name="Zeile[53][1]" value="-0.4" readonly></td></tr>
 <tr><td class="variablenname">albedo2</td>
-<td><input type="text" name="Zeile[50][1]" value="0.2" readonly></td></tr>
+<td><input type="text" name="Zeile[54][1]" value="0.2" readonly></td></tr>
 <tr><td class="variablenname">powerInverter2</td>
-<td><input type="text" name="Zeile[51][1]" value="8000" readonly></td></tr>
+<td><input type="text" name="Zeile[55][1]" value="8000" readonly></td></tr>
 <tr><td class="variablenname">inverterEfficiency2</td>
-<td><input type="text" name="Zeile[52][1]" value="1" readonly></td></tr>
+<td><input type="text" name="Zeile[56][1]" value="1" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Gewicht ermöglicht eine höhere Gewichtung des Wetterdienstes (je größer der Wert, umso größer das Gewicht)<br>; Gewicht = 0; die Prognose wird nicht zur Berechnung der Durchschnittsprognose verwendet. </td></tr>
 <tr><td class="variablenname">Gewicht</td>
-<td><input type="text" name="Zeile[54][1]" value="1" readonly></td></tr>
-<tr><td colspan="2"><input type="hidden" name="Zeile[55]" value='' ></td></tr>
-<tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[56]" value='[solarprognose]' >[solarprognose]</td></tr>
+<td><input type="text" name="Zeile[58][1]" value="1" readonly></td></tr>
+<tr><td colspan="2"><input type="hidden" name="Zeile[59]" value='' ></td></tr>
+<tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[60]" value='[solarprognose]' >[solarprognose]</td></tr>
 <tr class="comment"><td colspan="2">; Hier die Werte eintragen, wenn die Prognose mit Solarprognose_WeatherData.py von http://www.solarprognose.de geholt werden soll </td></tr>
 <tr><td class="variablenname">accesstoken</td>
-<td><input type="text" name="Zeile[58][1]" value="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" readonly></td></tr>
+<td><input type="text" name="Zeile[62][1]" value="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" readonly></td></tr>
 <tr><td class="variablenname">item</td>
-<td><input type="text" name="Zeile[59][1]" value="inverter" readonly></td></tr>
+<td><input type="text" name="Zeile[63][1]" value="inverter" readonly></td></tr>
 <tr><td class="variablenname">id</td>
-<td><input type="text" name="Zeile[60][1]" value="1111" readonly></td></tr>
+<td><input type="text" name="Zeile[64][1]" value="1111" readonly></td></tr>
 <tr><td class="variablenname">type</td>
-<td><input type="text" name="Zeile[61][1]" value="hourly" readonly></td></tr>
-<tr class="comment"><td colspan="2">; der Zeitversatz verschiebt die Prognose um X Stunden nach vor (-) oder nach hinten. </td></tr>
-<tr><td class="variablenname">Zeitversatz</td>
-<td><input type="text" name="Zeile[63][1]" value="0" readonly></td></tr>
+<td><input type="text" name="Zeile[65][1]" value="hourly" readonly></td></tr>
+<tr class="comment"><td colspan="2">; Wenn die Prognosekurve zur Produktionskurve generell verschoben ist, kann die Zeit hiermit um X Minuten verschoben werden<br>; Positive Werte = früher (nach links),negative = später (nach rechts). </td></tr>
+<tr><td class="variablenname">offset_minuten</td>
+<td><input type="text" name="Zeile[67][1]" value="0" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Sekunden des sleep = Vorgabe von solarprognose.de </td></tr>
 <tr><td class="variablenname">WaitSec</td>
-<td><input type="text" name="Zeile[65][1]" value="21" readonly></td></tr>
+<td><input type="text" name="Zeile[69][1]" value="21" readonly></td></tr>
 <tr class="comment"><td colspan="2">; mögliche Werte mosmix|own-v1|clearsky, für mosmix muss dem Standort eine Mosmix Station zugeordnet sein.<br>; Karte mit Stationen: https://wettwarn.de/mosmix/mosmix.html </td></tr>
 <tr><td class="variablenname">algorithm</td>
-<td><input type="text" name="Zeile[67][1]" value="own-v1" readonly></td></tr>
+<td><input type="text" name="Zeile[71][1]" value="own-v1" readonly></td></tr>
 <tr class="comment"><td colspan="2">; falls die Anlagengröße in KWp nicht mit der Größe in Solarprognose übereinstimmt (z.B. Erweiterung) </td></tr>
 <tr><td class="variablenname">KW_Faktor</td>
-<td><input type="text" name="Zeile[69][1]" value="1.00" readonly></td></tr>
+<td><input type="text" name="Zeile[73][1]" value="1.00" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Gewicht ermöglicht eine höhere Gewichtung des Wetterdienstes (je größer der Wert, umso größer das Gewicht)<br>; Gewicht = 0; die Prognose wird nicht zur Berechnung der Durchschnittsprognose verwendet. </td></tr>
 <tr><td class="variablenname">Gewicht</td>
-<td><input type="text" name="Zeile[71][1]" value="1" readonly></td></tr>
-<tr><td colspan="2"><input type="hidden" name="Zeile[72]" value='' ></td></tr>
-<tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[73]" value='[solcast.com]' >[solcast.com]</td></tr>
+<td><input type="text" name="Zeile[75][1]" value="1" readonly></td></tr>
+<tr><td colspan="2"><input type="hidden" name="Zeile[76]" value='' ></td></tr>
+<tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[77]" value='[solcast.com]' >[solcast.com]</td></tr>
 <tr class="comment"><td colspan="2">; Hier die Werte eintragen, wenn die Prognose mit Solcast_WeatherData.py von https://api.solcast.com.au geholt werden soll </td></tr>
 <tr><td class="variablenname">api_key</td>
-<td><input type="text" name="Zeile[75][1]" value="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" readonly></td></tr>
+<td><input type="text" name="Zeile[79][1]" value="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" readonly></td></tr>
 <tr><td class="variablenname">resource_id</td>
-<td><input type="text" name="Zeile[76][1]" value="xxxx-xxxx-xxxx-xxxx" readonly></td></tr>
+<td><input type="text" name="Zeile[80][1]" value="xxxx-xxxx-xxxx-xxxx" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Zeitversatz zu UTC, hier für Zeitzone Europe/Berlin UTC +1, Sommerzeit = +1 erfolgt nun automatisch. </td></tr>
 <tr><td class="variablenname">Zeitzone</td>
-<td><input type="text" name="Zeile[78][1]" value="+1" readonly></td></tr>
+<td><input type="text" name="Zeile[82][1]" value="+1" readonly></td></tr>
+<tr class="comment"><td colspan="2">; Wenn die Prognosekurve zur Produktionskurve generell verschoben ist, kann die Zeit hiermit um X Minuten verschoben werden<br>; Positive Werte = früher (nach links),negative = später (nach rechts). </td></tr>
+<tr><td class="variablenname">offset_minuten</td>
+<td><input type="text" name="Zeile[84][1]" value="0" readonly></td></tr>
 <tr><td class="variablenname">KW_Faktor</td>
-<td><input type="text" name="Zeile[79][1]" value="1.00" readonly></td></tr>
+<td><input type="text" name="Zeile[85][1]" value="1.00" readonly></td></tr>
 <tr class="comment"><td colspan="2">; spezifische Werte für eventuellen 2. String: </td></tr>
 <tr><td class="variablenname">resource_id2</td>
-<td><input type="text" name="Zeile[81][1]" value="xxxx-xxxx-xxxx-xxxx" readonly></td></tr>
+<td><input type="text" name="Zeile[87][1]" value="xxxx-xxxx-xxxx-xxxx" readonly></td></tr>
 <tr><td class="variablenname">KW_Faktor2</td>
-<td><input type="text" name="Zeile[82][1]" value="1.00" readonly></td></tr>
+<td><input type="text" name="Zeile[88][1]" value="1.00" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Gewicht ermöglicht eine höhere Gewichtung des Wetterdienstes ( je Größer der Wert umso größer das Gewicht)<br>; Gewicht = 0; die Prognose wird nicht zur Berechnung der Durchschnittsprognose verwendet. </td></tr>
 <tr><td class="variablenname">Gewicht</td>
-<td><input type="text" name="Zeile[84][1]" value="1" readonly></td></tr>
-<tr><td colspan="2"><input type="hidden" name="Zeile[85]" value='' ></td></tr>
-<tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[86]" value='[openmeteo]' >[openmeteo]</td></tr>
-<tr class="comment"><td colspan="2">; Infos zur API siehe https://open-meteo.com/en/docs<br>; Wenn die Prognosekurve zur Produktionskurve generell verschoben ist, kann sie hiermit um X Minuten verschoben werden </td></tr>
+<td><input type="text" name="Zeile[90][1]" value="1" readonly></td></tr>
+<tr><td colspan="2"><input type="hidden" name="Zeile[91]" value='' ></td></tr>
+<tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[92]" value='[openmeteo]' >[openmeteo]</td></tr>
+<tr class="comment"><td colspan="2">; Infos zur API siehe https://open-meteo.com/en/docs<br>; Wenn die Prognosekurve zur Produktionskurve generell verschoben ist, kann die Zeit hiermit um X Minuten verschoben werden<br>; Positive Werte = früher (nach links),negative = später (nach rechts). </td></tr>
 <tr><td class="variablenname">offset_minuten</td>
-<td><input type="text" name="Zeile[88][1]" value="0" readonly></td></tr>
+<td><input type="text" name="Zeile[94][1]" value="0" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Faktor des zusätzlichen Bewölkungseinflusses<br>; 0 = kein Einfluss =&gt; 1.0 starker Einfluss </td></tr>
 <tr><td class="variablenname">cloudEffect</td>
-<td><input type="text" name="Zeile[90][1]" value="0" readonly></td></tr>
+<td><input type="text" name="Zeile[96][1]" value="0" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Basis-Effizienzfaktor (systemische Verluste, nicht-optimale Bedingungen) </td></tr>
 <tr><td class="variablenname">base_efficiency_factor</td>
-<td><input type="text" name="Zeile[92][1]" value="0.90" readonly></td></tr>
+<td><input type="text" name="Zeile[98][1]" value="0.90" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Getestete Wettermodelle, Programm überprüft auf dies Modelle<br>; Liste kann erweitert werden </td></tr>
 <tr><td class="variablenname">valid_models</td>
-<td><input type="text" name="Zeile[94][1]" value="{&#039;icon_d2&#039;,&#039;icon_eu&#039;,&#039;ecmwf_aifs025_single&#039;}" readonly></td></tr>
+<td><input type="text" name="Zeile[100][1]" value="{&#039;icon_d2&#039;,&#039;icon_eu&#039;,&#039;ecmwf_aifs025_single&#039;}" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Verwendetes Wettermodel, es können  auch mehrere angegeben werden, der Werte dann gemittelt werden.<br>; z.B. icon_d2,icon_eu </td></tr>
 <tr><td class="variablenname">weather_models</td>
-<td><input type="text" name="Zeile[96][1]" value="icon_d2" readonly></td></tr>
+<td><input type="text" name="Zeile[102][1]" value="icon_d2" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Gewicht ermöglicht eine höhere Gewichtung des Wetterdienstes (je größer der Wert, umso größer das Gewicht)<br>; Gewicht = 0; die Prognose wird nicht zur Berechnung der Durchschnittsprognose verwendet. </td></tr>
 <tr><td class="variablenname">Gewicht</td>
-<td><input type="text" name="Zeile[98][1]" value="1" readonly></td></tr>
-<tr><td colspan="2"><input type="hidden" name="Zeile[99]" value='' ></td></tr>
-<tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[100]" value='[solcast_ha]' >[solcast_ha]</td></tr>
+<td><input type="text" name="Zeile[104][1]" value="1" readonly></td></tr>
+<tr><td colspan="2"><input type="hidden" name="Zeile[105]" value='' ></td></tr>
+<tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[106]" value='[solcast_ha]' >[solcast_ha]</td></tr>
 <tr class="comment"><td colspan="2">; Konfiguration für ADDONS/Solcast_WeatherData_from_HA_file.py von @roethigj<br>; Beschreibung siehe ADDONS/Solcast_WeatherData_from_HA_file.readme<br>; Hier den Pfad eintragen, wo die solecast.json vom HA Addon liegt<br>; (z.B. /usr/share/hassio/homeassistant/solcast.json) </td></tr>
 <tr><td class="variablenname">HA_weatherfile</td>
-<td><input type="text" name="Zeile[102][1]" value="/usr/share/hassio/homeassistant/solcast.json" readonly></td></tr>
+<td><input type="text" name="Zeile[108][1]" value="/usr/share/hassio/homeassistant/solcast.json" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Gewicht ermöglicht eine höhere Gewichtung des Wetterdienstes ( je Größer der Wert umso größer das Gewicht)<br>; Zeitversatz zu UTC, hier für Zeitzone Europe/Berlin UTC +1, Sommerzeit = +1 erfolgt nun automatisch. </td></tr>
 <tr><td class="variablenname">Zeitzone</td>
-<td><input type="text" name="Zeile[104][1]" value="+1" readonly></td></tr>
+<td><input type="text" name="Zeile[110][1]" value="+1" readonly></td></tr>
 <tr><td class="variablenname">KW_Faktor</td>
-<td><input type="text" name="Zeile[105][1]" value="1.00" readonly></td></tr>
+<td><input type="text" name="Zeile[111][1]" value="1.00" readonly></td></tr>
 <tr class="comment"><td colspan="2">; Gewicht ermöglicht eine höhere Gewichtung des Wetterdienstes (je größer der Wert, umso größer das Gewicht)<br>; Gewicht = 0; die Prognose wird nicht zur Berechnung der Durchschnittsprognose verwendet. </td></tr>
 <tr><td class="variablenname">Gewicht</td>
-<td><input type="text" name="Zeile[107][1]" value="1" readonly></td></tr>
-<tr><td colspan="2"><input type="hidden" name="Zeile[108]" value='' ></td></tr>
+<td><input type="text" name="Zeile[113][1]" value="1" readonly></td></tr>
+<tr><td colspan="2"><input type="hidden" name="Zeile[114]" value='' ></td></tr>
 </table><div id="Hilfezu/CONFIG/weatherini"></div><br><center><a href="#Hilfezu/CONFIG/chargeini" style="font-size: 2.0rem; text-decoration: none;">▼</a>&nbsp;&nbsp;<button type="submit">Hilfe zu charge.ini</button>&nbsp;&nbsp;<a href="#top" style="font-size: 2.0rem; text-decoration: none;">▲</a></center><br><br><table><tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[0]" value='[Hinweis]' >[Hinweis]</td></tr>
 <tr class="comment"><td colspan="2">; Bitte die original charge.ini nicht ändern, da sie bei Updates überschrieben wird.<br>; Persönliche Anpassungen stattdessen in einer Kopie als charge_priv.ini ablegen. </td></tr>
 <tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[2]" value='[Ladeberechnung]' >[Ladeberechnung]</td></tr>
@@ -672,6 +681,6 @@ Fast-forward
 <td><input type="text" name="Zeile[55][1]" value="ein" readonly></td></tr>
 <tr><td colspan="2"><input type="hidden" name="Zeile[56]" value='' ></td></tr>
 <tr><td colspan="2"><input type="hidden" name="Zeile[57]" value='' ></td></tr>
-</table><div id="Hilfezu/CONFIG//html/configini"></div><br /><br /><hr />Hilfe erzeugt am 12.04.2026 durch make_config_help.php&nbsp;&nbsp;<a href="#top" style="font-size: 2.0rem; text-decoration: none;">▲</a><br />
+</table><div id="Hilfezu/CONFIG//html/configini"></div><br /><br /><hr />Hilfe erzeugt am 23.04.2026 durch make_config_help.php&nbsp;&nbsp;<a href="#top" style="font-size: 2.0rem; text-decoration: none;">▲</a><br />
 </body>
 </html>

--- a/docs/WIKI/config.html
+++ b/docs/WIKI/config.html
@@ -508,7 +508,7 @@ Fast-forward
 <td><input type="text" name="Zeile[65][1]" value="{&quot;9&quot;: &quot;30&quot;}" readonly></td></tr>
 <tr><td colspan="2"><input type="hidden" name="Zeile[66]" value='' ></td></tr>
 <tr><td class="ini_block" colspan="2"><input type="hidden" name="Zeile[67]" value='[EigenverbOptimum]' >[EigenverbOptimum]</td></tr>
-<tr class="comment"><td colspan="2">; Nur HTTP<br>; durch das Setzen eines bestimmten Einspeisewertes unter Eigenverbrauchs-Optimierung<br>; kann über Nacht der Akku entladen werden<br>; EigenverbOpt_steuern 0 = aus, 1 = ein und Tagesoptimierung nach Prognose, 2 = nachts ein und tags aus </td></tr>
+<tr class="comment"><td colspan="2">; durch das Setzen eines bestimmten Einspeisewertes unter Eigenverbrauchs-Optimierung<br>; kann über Nacht der Akku entladen werden<br>; EigenverbOpt_steuern 0 = aus, 1 = ein und Tagesoptimierung nach Prognose, 2 = nachts ein und tags aus </td></tr>
 <tr><td class="variablenname">EigenverbOpt_steuern</td>
 <td><input type="text" name="Zeile[69][1]" value="0" readonly></td></tr>
 <tr><td class="variablenname">GrundlastNacht</td>
@@ -681,6 +681,6 @@ Fast-forward
 <td><input type="text" name="Zeile[55][1]" value="ein" readonly></td></tr>
 <tr><td colspan="2"><input type="hidden" name="Zeile[56]" value='' ></td></tr>
 <tr><td colspan="2"><input type="hidden" name="Zeile[57]" value='' ></td></tr>
-</table><div id="Hilfezu/CONFIG//html/configini"></div><br /><br /><hr />Hilfe erzeugt am 23.04.2026 durch make_config_help.php&nbsp;&nbsp;<a href="#top" style="font-size: 2.0rem; text-decoration: none;">▲</a><br />
+</table><div id="Hilfezu/CONFIG//html/configini"></div><br /><br /><hr />Hilfe erzeugt am 27.04.2026 durch make_config_help.php&nbsp;&nbsp;<a href="#top" style="font-size: 2.0rem; text-decoration: none;">▲</a><br />
 </body>
 </html>

--- a/html/3_tab_wallbox.php
+++ b/html/3_tab_wallbox.php
@@ -150,6 +150,7 @@ $phase_change_confirm_s = $EV_Reservierung['3']['Options'] ?? 30;        // PHAS
 // Neue Einstellungen ID=4 (Ladezeiten)
 $ladezeit_von = $EV_Reservierung['4']['Res_Feld1'] ?? "12:00";
 $ladezeit_bis = $EV_Reservierung['4']['Res_Feld2'] ?? "05:00";
+$max_leistung_ha = $EV_Reservierung['4']['Options'] ?? "-0.1";
 
 // Neue Einstellungen ID=5 (Preise)
 $strompreis_fest = $EV_Reservierung['5']['Res_Feld1'] ?? 0.30;
@@ -567,6 +568,11 @@ echo $html;
             <span class="input-inline"><input id="residualPower" type="number" step="100" value="<?php echo htmlspecialchars($residualPower); ?>"></span>
         </div>
 
+        <div class="row">
+            <span class="label-inline">Ladebegr. Hausakku(kW) (DB=<?php echo htmlspecialchars($max_leistung_ha); ?>):</span>
+            <span class="input-inline"><input id="MaxLeistHAkW" type="number" step="0.1" min="-0.1" value="<?php echo htmlspecialchars($max_leistung_ha); ?>"></span>
+        </div>
+
         <hr>
         </details>
         <br>
@@ -594,7 +600,7 @@ function loadFromLocalStorage(id) {
 
 $(document).ready(function(){
     // IDs, die wir im localStorage zwischenhalten möchten
-    var ls_ids = ['pvMode','phases','ampMin','ampMax','autoSyncInterval','minPhaseDur','minChargeDur','phaseChangeConfirm','residualPower','defaultTargetKwh'];
+    var ls_ids = ['pvMode','phases','ampMin','ampMax','autoSyncInterval','minPhaseDur','minChargeDur','phaseChangeConfirm','residualPower','defaultTargetKwh', 'MaxLeistHAkW'];
 
     // Load saved values
     ls_ids.forEach(function(id){ loadFromLocalStorage(id); });
@@ -820,6 +826,7 @@ function calculatePower() {
     // ID 4: Next Trip Zeiten (aus Grafik)
     var lz_von = $('#ladezeitVon').val();
     var lz_bis = $('#ladezeitBis').val();
+    var max_leistung_ha = $('#MaxLeistHAkW').val();
 
     // ID 5: Preise (aus Grafik)
     var s_preis = $('#strompreisFest').val();
@@ -858,7 +865,7 @@ function calculatePower() {
                 amp_min + "," + amp_max, // ID 1
                 auto_sync_interval,      // ID 2
                 phase_change_confirm,    // ID 3
-                "",                      // ID 4
+                max_leistung_ha,         // ID 4
                 ""                       // ID 5
             ]
         },
@@ -867,7 +874,8 @@ function calculatePower() {
             var ls_ids = [
                 'pvMode','phases','ampMin','ampMax','autoSyncInterval',
                 'minPhaseDur','minChargeDur','phaseChangeConfirm','residualPower',
-                'defaultTargetKwh', 'ladezeitVon', 'ladezeitBis', 'strompreisFest', 'einspeiseVerg'
+                'defaultTargetKwh', 'ladezeitVon', 'ladezeitBis', 'strompreisFest', 'einspeiseVerg',
+                'MaxLeistHAkW'
             ];
 
             ls_ids.forEach(function(id){

--- a/html/3_tab_wallbox.php
+++ b/html/3_tab_wallbox.php
@@ -396,20 +396,17 @@ p, label {
 $solar_current   = round(($meter_values['Produktion_W'] ?? 0) / 1000, 1);
 $battery_current = round(($meter_values['Batteriebezug_W'] ?? 0) / 1000, 1);
 $grid_current    = round(($meter_values['Netzbezug_W'] ?? 0) / 1000, 1);
+$Hausverbrauch    = round(($meter_values['Hausverbrauch'] ?? 0) / 1000, 1);
 
 // 2. Ladeleistung 
-// Wir nehmen den realen Messwert, filtern aber Standby-Rauschen unter 300W/0.3kW
+// Wir nehmen den realen Messwert, filtern aber Standby-Rauschen unter 200W/0.2kW
 $car_power = round(($meter_values['power_w'] ?? 0) / 1000, 1);
-if ($car_power < 0.3) $car_power = 0;
+if ($car_power < 0.2) $car_power = 0;
 
-// 3. Hausverbrauch als mathematischer Rest
-// Die Summe der Quellen minus die Wallbox ergibt zwingend das Haus.
-$Q_sum = $solar_current + $battery_current + $grid_current;
-$Hausverbrauch = round($Q_sum - $car_power, 1);
-
-// 4. Plausibilitäts-Korrektur, Hausverbrauch immer darstellen
+// 3. Plausibilitäts-Korrektur, Hausverbrauch immer darstellen
 // Falls die Wallbox-Daten hängen (alt/hoch) und die Erzeugung sinkt (neu/niedrig),
 // würde der Hausverbrauch negativ. Das korrigieren wir hier zugunsten der Anzeige.
+$Q_sum = $solar_current + $battery_current + $grid_current;
 if ($Hausverbrauch < 0.1) {
     $Hausverbrauch = 0.2; // Mindestlast Haus (Kühlschrank/Standby)
     // Wir passen die Car-Power an, damit die Bar optisch perfekt bleibt
@@ -418,7 +415,7 @@ if ($Hausverbrauch < 0.1) {
     }
 }
 
-// 5. Balkendiagramm generieren
+// 4. Balkendiagramm generieren
 [ $html, $Q_final, $Z_final ] = generateLoadBar($solar_current, $battery_current, $grid_current, $car_power, $Hausverbrauch);
 
 echo $html; 

--- a/html/3_tab_wallbox.php
+++ b/html/3_tab_wallbox.php
@@ -147,6 +147,14 @@ $residualPower        = $EV_Reservierung['3']['Res_Feld1'] ?? -300;      // resi
 $default_target_kwh   = $EV_Reservierung['3']['Res_Feld2'] ?? 0.0;        // DEFAULT_TARGET_KWH
 $phase_change_confirm_s = $EV_Reservierung['3']['Options'] ?? 30;        // PHASE_CHANGE_CONFIRM_S
 
+// Neue Einstellungen ID=4 (Ladezeiten)
+$ladezeit_von = $EV_Reservierung['4']['Res_Feld1'] ?? "12:00";
+$ladezeit_bis = $EV_Reservierung['4']['Res_Feld2'] ?? "05:00";
+
+// Neue Einstellungen ID=5 (Preise)
+$strompreis_fest = $EV_Reservierung['5']['Res_Feld1'] ?? 0.30;
+$einspeise_verg  = $EV_Reservierung['5']['Res_Feld2'] ?? 0.07;
+
 // -------------------------
 // AJAX poll
 // -------------------------
@@ -454,6 +462,7 @@ echo $html;
                 <option value="1" <?php if($pv_mode=='1') echo 'selected'; ?>>PV</option>
                 <option value="2" <?php if($pv_mode=='2') echo 'selected'; ?>>MIN+PV</option>
                 <option value="3" <?php if($pv_mode=='3') echo 'selected'; ?>>MAX</option>
+                <option value="4" <?php if($pv_mode=='4') echo 'selected'; ?>>NextTrip</option>
             </select>
             </span>
         </div>
@@ -490,11 +499,48 @@ echo $html;
             </select>
             <span id="powerMax" class="small" style="margin-left: 10px;">(— kW)</span> </span>
         </div>
+        <div class="row">
+            <span class="label-inline">Lademenge(kWh) (DB=<?php echo htmlspecialchars($default_target_kwh); ?>):</span>
+            <span class="input-inline"><input id="defaultTargetKwh" type="number" step="1" min="0" value="<?php echo htmlspecialchars($default_target_kwh); ?>"></span>
+        </div>
+        <hr>
 
+        <details id="nextTripOptions" <?php echo ($pv_mode == '4') ? 'open' : ''; ?>>
+            <summary><b>Next Trip Optionen:</b></summary>
+
+            <div class="row">
+                <span class="label-inline">Ladezeit-von (DB=<?php echo htmlspecialchars($ladezeit_von); ?>):</span>
+                <span class="input-inline">
+                    <input id="ladezeitVon" type="text"
+                        value="<?php echo htmlspecialchars($ladezeit_von); ?>"
+                        placeholder="HH:MM"
+                        style="cursor: s-resize;">
+                </span>
+            </div>
+
+            <div class="row">
+                <span class="label-inline">Ladezeit-bis (DB=<?php echo htmlspecialchars($ladezeit_bis); ?>):</span>
+                <span class="input-inline">
+                    <input id="ladezeitBis" type="text"
+                        value="<?php echo htmlspecialchars($ladezeit_bis); ?>"
+                        placeholder="HH:MM"
+                        style="cursor: s-resize;">
+                </span>
+            </div>
+
+            <div class="row">
+                <span class="label-inline">Strompreis-fest (€) (DB=<?php echo htmlspecialchars($strompreis_fest); ?>):</span>
+                <span class="input-inline"><input id="strompreisFest" type="number" step="0.001" value="<?php echo htmlspecialchars($strompreis_fest); ?>"></span>
+            </div>
+
+            <div class="row">
+                <span class="label-inline">Einspeisevergütung (€) (DB=<?php echo htmlspecialchars($einspeise_verg); ?>):</span>
+                <span class="input-inline"><input id="einspeiseVerg" type="number" step="0.001" value="<?php echo htmlspecialchars($einspeise_verg); ?>"></span>
+            </div>
+        </details>
         <hr>
         <details id="moreOptions">
             <summary><b>Erweiterte Optionen:</b></summary>
-        <h3>Timing Einstellungen:</h3>
 
         <div class="row">
             <span class="label-inline">Wallboxaktualisierung(s) (DB=<?php echo htmlspecialchars($auto_sync_interval); ?>):</span>
@@ -516,19 +562,12 @@ echo $html;
             <span class="input-inline"><input id="phaseChangeConfirm" type="number" min="0" step="30" value="<?php echo htmlspecialchars($phase_change_confirm_s); ?>"></span>
         </div>
 
-        <hr>
-        <h3>Sonstige Zielwerte:</h3>
-
         <div class="row">
             <span class="label-inline">Verbleibende Leistung(W) (DB=<?php echo htmlspecialchars($residualPower); ?>):</span>
             <span class="input-inline"><input id="residualPower" type="number" step="100" value="<?php echo htmlspecialchars($residualPower); ?>"></span>
         </div>
 
-        <div class="row">
-            <span class="label-inline">Lademenge(kWh) (DB=<?php echo htmlspecialchars($default_target_kwh); ?>):</span>
-            <span class="input-inline"><input id="defaultTargetKwh" type="number" step="1" min="0" value="<?php echo htmlspecialchars($default_target_kwh); ?>"></span>
-        </div>
-
+        <hr>
         </details>
         <br>
         <button type="button" id="btnSave" class="ocpp schreiben">Speichern</button>
@@ -563,6 +602,105 @@ $(document).ready(function(){
     // Save on change
     ls_ids.forEach(function(id){ 
         $('#' + id).on('change input', function(){ saveToLocalStorage(id); });
+    });
+
+    // --- Logik für Next Trip Optionen Sichtbarkeit ---
+    function toggleNextTripVisibility() {
+        var selectedMode = $('#pvMode').val();
+        var nextTripDetails = document.getElementById('nextTripOptions');
+
+        if (selectedMode === '4') { // '4' ist NextTrip
+            nextTripDetails.setAttribute('open', 'open');
+        } else {
+            nextTripDetails.removeAttribute('open');
+        }
+    }
+
+    // Bei Änderung des PV-Modus umschalten
+    $('#pvMode').on('change', toggleNextTripVisibility);
+
+    // --- Bestehende Logik für "Erweiterte Optionen" (moreOptions) ---
+    // Diese bleibt unverändert, da sie bereits den User-Status via localStorage speichert
+    var moreOptionsKey = 'moreOptionsOpen';
+    var moreOptionsEl = document.getElementById('moreOptions');
+    if (moreOptionsEl) {
+        var stored = localStorage.getItem(moreOptionsKey);
+        if (stored === '1') {
+            moreOptionsEl.setAttribute('open', 'open');
+        } else {
+            moreOptionsEl.removeAttribute('open');
+        }
+        moreOptionsEl.addEventListener('toggle', function(){
+            localStorage.setItem(moreOptionsKey, this.open ? '1' : '0');
+        });
+    }
+
+    // --- Zentrale Funktion zum Formatieren & Runden ---
+    function formatAndRoundTime(inputVal) {
+        // Entferne alles außer Zahlen und Doppelpunkt
+        var clean = inputVal.replace(/[^0-9:]/g, '');
+
+        // Falls nur Zahlen eingegeben wurden (z.B. 1200 -> 12:00)
+        if (clean.length === 4 && clean.indexOf(':') === -1) {
+            clean = clean.substr(0, 2) + ':' + clean.substr(2, 2);
+        }
+
+        var parts = clean.split(':');
+        var h = parseInt(parts[0], 10) || 0;
+        var m = parseInt(parts[1], 10) || 0;
+
+        // Stunden auf 0-23 begrenzen
+        h = Math.min(Math.max(h, 0), 23);
+
+        // Minuten auf das nächste 15er Intervall runden
+        m = Math.round(m / 15) * 15;
+        if (m >= 60) {
+            m = 0;
+            h = (h + 1) % 24;
+        }
+
+        return (h < 10 ? '0' + h : h) + ":" + (m < 10 ? '0' + m : m);
+    }
+
+    // --- Blätter-Funktion (wie zuvor) ---
+    function scrollTime(input, direction) {
+        var current = formatAndRoundTime($(input).val());
+        var parts = current.split(':');
+        var totalMinutes = parseInt(parts[0]) * 60 + parseInt(parts[1]) + (direction * 15);
+
+        if (totalMinutes < 0) totalMinutes += 1440;
+        if (totalMinutes >= 1440) totalMinutes -= 1440;
+
+        var newH = Math.floor(totalMinutes / 60);
+        var newM = totalMinutes % 60;
+        var formatted = (newH < 10 ? '0' + newH : newH) + ":" + (newM < 10 ? '0' + newM : newM);
+        $(input).val(formatted).trigger('change');
+    }
+
+    // --- EVENTS ---
+
+    // 1. Manuelle Eingabe korrigieren beim Verlassen des Feldes
+    $('#ladezeitVon, #ladezeitBis').on('blur', function() {
+        var corrected = formatAndRoundTime($(this).val());
+        $(this).val(corrected);
+    });
+
+    // 2. Mausrad-Blättern
+    $('#ladezeitVon, #ladezeitBis').on('wheel', function(e) {
+        e.preventDefault();
+        var direction = e.originalEvent.deltaY < 0 ? 1 : -1;
+        scrollTime(this, direction);
+    });
+
+    // 3. Tastatur-Blättern (Pfeiltasten)
+    $('#ladezeitVon, #ladezeitBis').on('keydown', function(e) {
+        if (e.which === 38) { // Hoch
+            e.preventDefault();
+            scrollTime(this, 1);
+        } else if (e.which === 40) { // Runter
+            e.preventDefault();
+            scrollTime(this, -1);
+        }
     });
     
 // ===================================
@@ -634,61 +772,115 @@ function calculatePower() {
             }
         });
     }
+    // =========================================================================
+    // NEU: Sichtbarkeit der Next Trip Optionen steuern
+    // =========================================================================
+    function updateNextTripVisibility() {
+        var selectedMode = $('#pvMode').val();
+        var nextTripDetails = document.getElementById('nextTripOptions');
+
+        if (nextTripDetails) {
+            // Nur wenn Modus "4" (NextTrip) gewählt ist, aufklappen
+            if (selectedMode === '4') {
+                nextTripDetails.setAttribute('open', 'open');
+            } else {
+                nextTripDetails.removeAttribute('open');
+            }
+        }
+    }
+
+    // Sofort beim Laden der Seite ausführen
+    updateNextTripVisibility();
+
+    // Bei jeder Änderung des PV-Modus-Dropdowns ausführen
+    $('#pvMode').on('change', function() {
+        updateNextTripVisibility();
+    });
+    // =========================================================================
 
     $('#btnSave').click(function(){
-        var amp_min = $('#ampMin').val();
-        var amp_max = $('#ampMax').val();
-        var phases = $('#phases').val();
-        var pv_mode = $('#pvMode').val();
-        var cp_id = $('#selectedCpId').val(); // Ausgewählte Client-ID (kann leer sein)
+    // --- Daten sammeln ---
 
-        // Neue Parameter (ID=2)
-        var auto_sync_interval = $('#autoSyncInterval').val();
-        var min_phase_dur = $('#minPhaseDur').val();
-        var min_charge_dur = $('#minChargeDur').val();
+    // ID 1: Basis-Einstellungen
+    var pv_mode = $('#pvMode').val();
+    var phases = $('#phases').val();
+    var amp_min = $('#ampMin').val();
+    var amp_max = $('#ampMax').val();
 
-        // Neue Parameter (ID=3)
-        var phase_change_confirm = $('#phaseChangeConfirm').val();
-        var residual_power = $('#residualPower').val();
-        var default_target_kwh = $('#defaultTargetKwh').val();
+    // ID 2: Zeitintervalle
+    var auto_sync_interval = $('#autoSyncInterval').val();
+    var min_phase_dur = $('#minPhaseDur').val();
+    var min_charge_dur = $('#minChargeDur').val();
 
-        $.ajax({
-            url: "SQL_speichern.php",
-            method: "post",
-            data: {
-                ID: ["1","2","3"],
-                Schluessel: ["wallbox","wallbox","wallbox"],
-                Tag_Zeit: ["1","2","3"],
-                // Res_Feld1 for each ID:
-                // ID=1 -> pv_mode
-                // ID=2 -> MIN_PHASE_DURATION_S
-                // ID=3 -> residualPower
-                Res_Feld1: [pv_mode, min_phase_dur, residual_power],
-                // Res_Feld2 for each ID:
-                // ID=1 -> phases
-                // ID=2 -> MIN_CHARGE_DURATION_S
-                // ID=3 -> DEFAULT_TARGET_KWH
-                Res_Feld2: [phases, min_charge_dur, default_target_kwh],
-                // Options for each ID:
-                // ID=1 -> amp_min,amp_max
-                // ID=2 -> AUTO_SYNC_INTERVAL
-                // ID=3 -> PHASE_CHANGE_CONFIRM_S
-                Options: [amp_min + "," + amp_max, auto_sync_interval, phase_change_confirm]
-            },
-            success: function(data){
-                // Nach erfolgreichem Speichern die lokalen Werte löschen,
-                // damit beim nächsten Neuladen die NEUEN DB-Werte angezeigt werden.
-                ls_ids.forEach(function(id){ localStorage.removeItem(id); });
+    // ID 3: Leistung & Target
+    var phase_change_confirm = $('#phaseChangeConfirm').val();
+    var residual_power = $('#residualPower').val();
+    var default_target_kwh = $('#defaultTargetKwh').val();
 
-                // Hinweis: Den Zustand von "Mehr Optionen" NICHT löschen, damit Benutzer-Einstellung erhalten bleibt.
+    // ID 4: Next Trip Zeiten (aus Grafik)
+    var lz_von = $('#ladezeitVon').val();
+    var lz_bis = $('#ladezeitBis').val();
 
-                // Nach dem Speichern auf die Seite des ausgewählten Clients neu laden
-                refreshData();
-            },
-            error: function(xhr, status, err) {
-                alert("Fehler beim Speichern: " + err);
-            }
-        });
+    // ID 5: Preise (aus Grafik)
+    var s_preis = $('#strompreisFest').val();
+    var e_verg  = $('#einspeiseVerg').val();
+
+    // --- AJAX Request ---
+    $.ajax({
+        url: "SQL_speichern.php",
+        method: "post",
+        data: {
+            // Die Arrays müssen exakt gleich lang sein (5 Einträge)
+            ID:         ["1", "2", "3", "4", "5"],
+            Schluessel: ["wallbox", "wallbox", "wallbox", "wallbox", "wallbox"],
+            Tag_Zeit:   ["1", "2", "3", "4", "5"],
+
+            // Zuordnung Res_Feld1
+            Res_Feld1: [
+                pv_mode,           // ID 1
+                min_phase_dur,     // ID 2
+                residual_power,    // ID 3
+                lz_von,            // ID 4
+                s_preis            // ID 5
+            ],
+
+            // Zuordnung Res_Feld2
+            Res_Feld2: [
+                phases,            // ID 1
+                min_charge_dur,    // ID 2
+                default_target_kwh,// ID 3
+                lz_bis,            // ID 4
+                e_verg             // ID 5
+            ],
+
+            // Zuordnung Options
+            Options: [
+                amp_min + "," + amp_max, // ID 1
+                auto_sync_interval,      // ID 2
+                phase_change_confirm,    // ID 3
+                "",                      // ID 4
+                ""                       // ID 5
+            ]
+        },
+        success: function(response){
+            // LocalStorage aufräumen, damit beim Refresh die neuen DB-Werte geladen werden
+            var ls_ids = [
+                'pvMode','phases','ampMin','ampMax','autoSyncInterval',
+                'minPhaseDur','minChargeDur','phaseChangeConfirm','residualPower',
+                'defaultTargetKwh', 'ladezeitVon', 'ladezeitBis', 'strompreisFest', 'einspeiseVerg'
+            ];
+
+            ls_ids.forEach(function(id){
+                localStorage.removeItem(id);
+            });
+
+            // Seite neu laden (mit Scroll-Position-Erhalt durch deinen bestehenden Listener)
+            refreshData();
+        },
+        error: function(xhr, status, err) {
+            alert("Fehler beim Speichern in die Datenbank: " + err);
+        }
+     });
     });
 });
 

--- a/html/7_funktion_Diagram.php
+++ b/html/7_funktion_Diagram.php
@@ -271,108 +271,105 @@ function getSQL($SQLType, $DiaDatenVon, $DiaDatenBis, $groupSTR)
     // Standard-Rückgabe, falls $SQLType nicht erkannt wird (jetzt nur diese 3 Fälle)
     return null;
 }
-function Preisberechnung($DiaDatenVon, $DiaDatenBis, $groupSTR, $db)  # KI optimiert
-{  
+
+function Preisberechnung($DiaDatenVon, $DiaDatenBis, $groupSTR, $db)  # KI optimiert & Korrigiert
+{
     $Preisstatistik = [];
     $Zeitraeume = ["T", "M", "J"];
 
-    // 1. Ursprüngliche Grenzen speichern. Wichtig, da die Grenzen in der Schleife verändert werden.
     $Original_DiaDatenVon = $DiaDatenVon;
     $Original_DiaDatenBis = $DiaDatenBis;
 
-    // SQL-Vorlage mit Platzhaltern für die Datumsangaben
+    // DAS NEUE SQL-TEMPLATE
     $SQL_TEMPLATE = "
     WITH Stündlicher_Netzverbrauch AS (
-        -- Schritt 1: Aggregiere den Netzverbrauch (letzter Zählerstand) pro Stunde
         SELECT
             STRFTIME('%Y-%m-%d %H:00:00', Zeitpunkt) AS Stunde,
             MAX(Netzverbrauch) AS Netzverbrauch_Stunde
         FROM pv_daten
         WHERE Zeitpunkt BETWEEN '{{DiaDatenVon}}' AND '{{DiaDatenBis}}'
         GROUP BY Stunde
-    )
-    , Stündlicher_Netzbezug AS (
-        -- Schritt 2: Berechne den Netzbezug (Verbrauch) pro Stunde mit LEAD
+    ),
+    Stündlicher_Netzbezug AS (
         SELECT
             Stunde,
-            -- LEAD(Wert, 1) holt den Zählerstand der nächsten Stunde
             (LEAD(Netzverbrauch_Stunde, 1) OVER (ORDER BY Stunde) - Netzverbrauch_Stunde) AS Netzbezug
         FROM Stündlicher_Netzverbrauch
-        ORDER BY Stunde
+    ),
+    Marktpreise AS (
+        -- Hier holen wir ALLE Preise des Zeitraums ohne Filterung durch Verbrauch
+        SELECT Bruttopreis
+        FROM strompreise
+        WHERE Zeitpunkt BETWEEN '{{DiaDatenVon}}' AND '{{StatistikBis}}'
     )
-    , Berechnungsbasis AS (
-        -- Schritt 3: Preise zuordnen und Kosten berechnen
+    SELECT
+        -- Statistiken über den gesamten Marktzeitraum
+        ROUND((SELECT MIN(Bruttopreis) FROM Marktpreise), 2) AS MIN,
+        ROUND((SELECT MAX(Bruttopreis) FROM Marktpreise), 2) AS MAX,
+        ROUND((SELECT AVG(Bruttopreis) FROM Marktpreise), 2) AS AVG,
+
+        -- Deine persönlichen Kosten (nur wenn Netzbezug > 0)
+        ROUND(SUM(calc.Preis), 2) AS SUM,
+        ROUND(SUM(calc.Preis) / (SUM(calc.Netzbezug) / 1000.0), 2) AS KostSUM
+    FROM (
         SELECT
             sp.Bruttopreis,
             pv.Netzbezug,
             (pv.Netzbezug * sp.Bruttopreis / 1000.0) AS Preis
         FROM strompreise AS sp
-        INNER JOIN Stündlicher_Netzbezug AS pv
-            -- JOIN über die volle Stunde
-            ON sp.Zeitpunkt = pv.Stunde
-        WHERE
-            -- Filtern: Nur positiver Verbrauch und gültige Preise
-            pv.Netzbezug IS NOT NULL AND pv.Netzbezug > 0 AND sp.Bruttopreis IS NOT NULL
-    )
-    SELECT
-        ROUND(MIN(Bruttopreis), 2) AS MIN,
-        ROUND(MAX(Bruttopreis), 2) AS MAX,
-        ROUND(AVG(Bruttopreis), 2) AS AVG,
-        ROUND(SUM(Preis), 2) AS SUM,
-        -- KostSUM: Gesamtkosten / Gesamtverbrauch (in kWh, daher /1000.0)
-        ROUND((SUM(Preis) / (SUM(Netzbezug) / 1000.0)), 2) AS KostSUM
-    FROM Berechnungsbasis;
+        INNER JOIN Stündlicher_Netzbezug AS pv ON sp.Zeitpunkt = pv.Stunde
+        WHERE pv.Netzbezug > 0 AND pv.Stunde < '{{StatistikBis}}'
+    ) AS calc;
     ";
 
-    // 2. Schleife für Tag, Monat, Jahr
     foreach ($Zeitraeume as $Zeitraum) {
-
-        // Aktuelle Zeitgrenzen für diesen Durchlauf
         $Aktuell_Von = $Original_DiaDatenVon;
         $Aktuell_Bis = $Original_DiaDatenBis;
+        $Statistik_Bis = $Original_DiaDatenBis; // Hilfsvariable für die saubere Grenze
 
-        // Anpassen der Grenzen basierend auf dem Zeitraum (Monat oder Jahr)
         if ($Zeitraum == 'M') {
-            // Monat: Start am ersten Tag des Startmonats, Ende am ersten Tag des Folgemonats
             $date = new DateTime($Original_DiaDatenVon);
             $date->modify('first day of this month');
-            $Aktuell_Von = $date->format('Y-m-d H:i');
+            $Aktuell_Von = $date->format('Y-m-d 00:00:00');
 
             $date = new DateTime($Original_DiaDatenBis);
             $date->modify('first day of next month');
-            $Aktuell_Bis = $date->format('Y-m-d H:i');
+            $Aktuell_Bis = $date->format('Y-m-d 00:05:00'); // Puffer für LEAD
+            $Statistik_Bis = $date->modify('-5 minutes')->format('Y-m-d 23:59:59'); // Ende des Monats
         }
 
         if ($Zeitraum == 'J') {
-            // Jahr: Start am 1. Januar des Startjahres, Ende am 1. Januar des Folgejahres
             $date = new DateTime($Original_DiaDatenVon);
             $date->modify('first day of January this year');
-            $Aktuell_Von = $date->format('Y-m-d H:i');
+            $Aktuell_Von = $date->format('Y-m-d 00:00:00');
 
             $date = new DateTime($Original_DiaDatenBis);
             $date->modify('first day of January next year');
-            $Aktuell_Bis = $date->format('Y-m-d H:i');
+            $Aktuell_Bis = $date->format('Y-m-d 00:05:00'); // Puffer für LEAD
+            $Statistik_Bis = $date->modify('-5 minutes')->format('Y-m-d 23:59:59'); // Ende des Jahres
         }
 
-        // 3. Platzhalter im SQL-Template ersetzen
+        // Falls Zeitraum 'T' (Tag), Statistik_Bis einfach auf Bis setzen
+        if ($Zeitraum == 'T') {
+             $Statistik_Bis = $Original_DiaDatenBis;
+        }
+
         $SQL = str_replace(
-            ['{{DiaDatenVon}}', '{{DiaDatenBis}}', '{{groupSTR}}'],
-            [$Aktuell_Von, $Aktuell_Bis, $groupSTR],
+            ['{{DiaDatenVon}}', '{{DiaDatenBis}}', '{{StatistikBis}}'],
+            [$Aktuell_Von, $Aktuell_Bis, $Statistik_Bis],
             $SQL_TEMPLATE
         );
 
-        // 4. Abfrage ausführen und Ergebnisse speichern
         $result = $db->query($SQL);
         if ($result) {
             $Preisstatistik[$Zeitraum] = $result->fetchArray(SQLITE3_ASSOC);
         } else {
-            // Fehlerbehandlung hinzufügen
             $Preisstatistik[$Zeitraum] = ['Error' => $db->lastErrorMsg()];
         }
     }
 
     return $Preisstatistik;
-} # ENDE function Preisberechnung
+}
 
 function Optionenausgabe($DBersterTag_Jahr, $activeTab)
 {

--- a/version.ini
+++ b/version.ini
@@ -1,2 +1,2 @@
 [Programm]
-version = v0.41.8
+version = v0.42.0


### PR DESCRIPTION
- Wallboxsteuerung: NextTrip mit notwendigen Anpassungen im Frontend hinzugefügt.  
- Wallboxsteuerung: Option zu Begrenzung der Ladeleistung des Hausakkus hinzugefügt.  
**Tests erwünscht:**

- Änderungen an den Prognoseskripten und in der CONFIG/weather.ini bzw. CONFIG/weather_priv.ini
  Alle Prognosedienste können nun mit der Variablen `offset_minuten` die Prognose verschieben.
  Deshalb wurde die Variable in den Blöcken der jeweiligen Prognosedienste hinzugefügt.
  **Änderungen in CONFIG/weather.ini**, bitte in `priv.ini` nachziehen.
